### PR TITLE
Updated X3d CDN link

### DIFF
--- a/spa/public/index.html
+++ b/spa/public/index.html
@@ -7,8 +7,8 @@
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
     <title>Cybertown</title>
-    <link rel="stylesheet" type="text/css" href="https://create3000.github.io/code/x_ite/4.7.0/dist/x_ite.css" />
-    <script type="text/javascript" src="https://create3000.github.io/code/x_ite/4.7.0/dist/x_ite.min.js"></script>
+    <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/create3000/x_ite@4.7.0/dist/x_ite.min.css" />
+    <script type="text/javascript" src="https://cdn.jsdelivr.net/gh/create3000/x_ite@4.7.0/dist/x_ite.min.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
The link to XITE we were using went dark, causing production to go down.

We really need to prioritize #51 