### PR TITLE
Socket timing

### DIFF
--- a/spa/src/pages/world-browser/WorldBrowserPage.vue
+++ b/spa/src/pages/world-browser/WorldBrowserPage.vue
@@ -533,6 +533,8 @@ export default Vue.extend({
 
       this.startSharedEvents();
 
+      this.startSocketListeners();
+
       this.loaded = true;
     },
   },
@@ -583,9 +585,6 @@ export default Vue.extend({
       deep: true,
       immediate: true,
     },
-  },
-  mounted() {
-    this.startSocketListeners();
   },
   beforeDestroy() {},
   async beforeCreate() {

--- a/spa/src/pages/world-browser/WorldBrowserPage.vue
+++ b/spa/src/pages/world-browser/WorldBrowserPage.vue
@@ -340,10 +340,9 @@ export default Vue.extend({
       delete this.users[id];
     },
     onSharedEvent(event): void {
-      let eventObj = event.detail;
-      for (let node of this.eventNodeMap.get(eventObj.name)) {
-        node[eventObj.type + "FromServer"] = this.TYPES[eventObj.type].fromJSON(
-          eventObj.value
+      for (let node of this.eventNodeMap.get(event.name)) {
+        node[event.type + "FromServer"] = this.TYPES[event.type].fromJSON(
+          event.value
         );
       }
     },
@@ -450,7 +449,7 @@ export default Vue.extend({
 
       this.eventNodeMap = new Map();
 
-      for (const eventNode of Array.from(sharedZone.events) as Array<any>) {
+      for (const eventNode of Array.from<any>(sharedZone.events)) {
         for (const typeName of Object.keys(this.TYPES)) {
           eventNode.addFieldCallback(typeName + "ToServer", {}, val => {
             // TODO: confirm validity of adding to possibly non-existent field

--- a/spa/src/pages/world-browser/WorldBrowserPage.vue
+++ b/spa/src/pages/world-browser/WorldBrowserPage.vue
@@ -450,7 +450,7 @@ export default Vue.extend({
 
       this.eventNodeMap = new Map();
 
-      for (const eventNode of sharedZone.events) {
+      for (const eventNode of Array.from(sharedZone.events)) {
         for (const typeName of Object.keys(this.TYPES)) {
           eventNode.addFieldCallback(typeName + "ToServer", {}, val => {
             // TODO: confirm validity of adding to possibly non-existent field

--- a/spa/src/pages/world-browser/WorldBrowserPage.vue
+++ b/spa/src/pages/world-browser/WorldBrowserPage.vue
@@ -470,11 +470,13 @@ export default Vue.extend({
       }
     },
     startSocketListeners(): void {
+      this.$socket.on("VERSION", event => this.onVersion(event));
+    }
+    start3DSocketListeners(): void {
       this.$socket.on("AV", event => this.onAvatarMoved(event));
       this.$socket.on("AV:del", event => this.onAvatarRemoved(event));
       this.$socket.on("AV:new", event => this.onAvatarAdded(event));
       this.$socket.on("SE", event => this.onSharedEvent(event));
-      this.$socket.on("VERSION", event => this.onVersion(event));
     },
     async startX3D(): Promise<any> {
       if (!this.browser) {
@@ -533,7 +535,7 @@ export default Vue.extend({
 
       this.startSharedEvents();
 
-      this.startSocketListeners();
+      this.start3DSocketListeners();
 
       this.loaded = true;
     },
@@ -585,6 +587,9 @@ export default Vue.extend({
       deep: true,
       immediate: true,
     },
+  },
+  mounted() {
+    this.startSocketListeners();
   },
   beforeDestroy() {},
   async beforeCreate() {

--- a/spa/src/pages/world-browser/WorldBrowserPage.vue
+++ b/spa/src/pages/world-browser/WorldBrowserPage.vue
@@ -450,7 +450,7 @@ export default Vue.extend({
 
       this.eventNodeMap = new Map();
 
-      for (const eventNode of Array.from(sharedZone.events)) {
+      for (const eventNode of Array.from(sharedZone.events) as Array<any>) {
         for (const typeName of Object.keys(this.TYPES)) {
           eventNode.addFieldCallback(typeName + "ToServer", {}, val => {
             // TODO: confirm validity of adding to possibly non-existent field


### PR DESCRIPTION
Only start listening to 3D-relevent sockets after browser initialized. Trying to listen before crashes code that expects the X3D browser to exist, and then when switching to 3D from 2D currently present avatars don't appear.