### PR TITLE
Update DB_HOST and DB_PORT in api/.env.example

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -1,6 +1,6 @@
 CHAT_WEBHOOK_URL="https://webhook.example"
-DB_HOST="db"
-DB_PORT=3306
+DB_HOST="127.0.0.1"
+DB_PORT=3360
 DB_USER="root"
 DB_PASS="pw"
 DB_DATABASE="cybertown"


### PR DESCRIPTION
These corrections allows me to run `npm run db:init` in `ctr/api` folder when following the installation instructions on the README.