### PR TITLE
Update Chat Username Format

### DIFF
--- a/spa/server.js
+++ b/spa/server.js
@@ -174,6 +174,7 @@ io.on("connection", async function(socket) {
                     msg: chatData.msg,
                     role: chatData.role,
                     new: true,
+                    exp: chatData.exp,
                 });
             }
         }


### PR DESCRIPTION
Updated username format in chat messages to show role username experience amount instead of username[role]. This is more correct to the way 3D chat was in CT.
![chatmessages](https://github.com/user-attachments/assets/5a013604-8a47-444a-bd56-5f0fc7c66b16)
