### PR TITLE
Restrict "Places" button visibility to admins.

### DIFF
--- a/spa/src/pages/admin/admin.vue
+++ b/spa/src/pages/admin/admin.vue
@@ -6,7 +6,7 @@
     <div class="mb-2">
       <router-link class="btn-ui" :to="{name: 'UserSearch'}">Members</router-link>
     </div>
-    <div class="mb-2">
+    <div class="mb-2" v-if="accessLevel.includes('admin')">
       <router-link class="btn-ui" :to="{name: 'PlaceSearch'}">Places</router-link>
     </div>
     <div class="mb-2" v-if="accessLevel.includes('admin')">


### PR DESCRIPTION
Added a conditional check to display the "Places" button only for users with 'admin' access level. This ensures proper access control and improves security.