### PR TITLE
Update role mapping for mall

### DIFF
--- a/api/src/services/place/place.service.ts
+++ b/api/src/services/place/place.service.ts
@@ -270,8 +270,8 @@ export class PlaceService {
         deputy: this.roleRepository.roleMap.FleaMarketDeputy,
       },
       mall: {
-        owner: this.roleRepository.roleMap.BankManager,
-        deputy: this.roleRepository.roleMap.BankCashier,
+        owner: this.roleRepository.roleMap.MallManager,
+        deputy: this.roleRepository.roleMap.MallDeputy,
       },
       outlands: {
         owner: this.roleRepository.roleMap.OutlandsChief,


### PR DESCRIPTION
Revised the owner and deputy roles for malls to use MallManager and MallDeputy instead of BankManager and BankCashier. This ensures role assignments align more accurately with their intended contexts.