### PR TITLE
Update Shared Object Control

### DIFF
--- a/spa/assets/externprotos/shared_xite.wrl
+++ b/spa/assets/externprotos/shared_xite.wrl
@@ -190,7 +190,7 @@ function set_vec3f (value, time) { vec3fToServer = value; }
 }
 
 PROTO SharedObject [
-exposedField SFVec3f translation 0 0 0
+exposedField SFVec3f translation 0 1.75 0
 exposedField SFRotation rotation 0 1 0 0
 exposedField SFString name ""
 exposedField SFString id ""

--- a/spa/src/pages/world-browser/WorldBrowserPage.vue
+++ b/spa/src/pages/world-browser/WorldBrowserPage.vue
@@ -225,7 +225,7 @@ export default Vue.extend({
         }
       });
       this.sharedObjects.push(request.data.object_instance);
-      this.addSharedObject(request.data.object_instance, browser)
+      this.addSharedObject(request.data.object_instance, browser);
       this.$socket.emit('SO', {
         event: 'add',
         objectId: objectId

--- a/spa/src/pages/world-browser/WorldBrowserPage.vue
+++ b/spa/src/pages/world-browser/WorldBrowserPage.vue
@@ -238,11 +238,13 @@ export default Vue.extend({
       await this.$http.post(`/object_instance/${  objectId  }/pickup`);
 
       // remove to the scene 
-      const browser = X3D.getBrowser();
-      const object = this.sharedObjectsMap.get(objectId);
-      browser.currentScene.removeRootNode(object);
-
-      this.sharedObjectsMap.delete(objectId);
+      if(this.$store.data.view3d) {
+        const browser = X3D.getBrowser();
+        const object = this.sharedObjectsMap.get(objectId);
+        browser.currentScene.removeRootNode(object);
+        this.sharedObjectsMap.delete(objectId);
+      }
+    
       this.sharedObjects = this.sharedObjects.filter(obj => obj.id != objectId);
       this.$socket.emit('SO', {
         event: 'remove',

--- a/spa/src/pages/world-browser/WorldBrowserPage.vue
+++ b/spa/src/pages/world-browser/WorldBrowserPage.vue
@@ -108,11 +108,9 @@ export default Vue.extend({
       inline.url = new X3D.MFString(obj.url);
       sharedObject.children[0] = inline;
       browser.currentScene.addRootNode(sharedObject);
-
       sharedObject.addFieldCallback("newPosition", {}, (pos) => {
         this.saveObjectLocation(obj.id);
       });
-
       sharedObject.addFieldCallback("newRotation", {}, (rot) => {
         this.saveObjectLocation(obj.id);
       });
@@ -227,7 +225,7 @@ export default Vue.extend({
         }
       });
       this.sharedObjects.push(request.data.object_instance);
-      this.addSharedObject(request.data.object_instance, browser);
+      this.addSharedObject(request.data.object_instance, browser)
       this.$socket.emit('SO', {
         event: 'add',
         objectId: objectId


### PR DESCRIPTION
Fixed issue where objects would not be removed from public objects lists in 2d when taken. Also updated where objects get defaulted to so that they no longer go to under the floor, but they still go to 0 on the x and y axis if user doesn't refresh before trying to move the object.