### PR TITLE
Update admin check logic in Members.vue

### DIFF
--- a/spa/src/pages/club/Members.vue
+++ b/spa/src/pages/club/Members.vue
@@ -84,7 +84,7 @@ export default Vue.extend({
       membersCount: 0,
       limit: 10,
       members: [],
-      isAdmin: true,
+      isAdmin: false,
       offset: 0,
       status: "member",
       orderBy: "username",
@@ -92,6 +92,15 @@ export default Vue.extend({
     };
   },
   methods: {
+    async checkAdmin() {
+      try {
+        const adminCheck = await this.$http
+          .get(`/place/can_admin/${this.$store.data.place.slug}/${this.$store.data.place.id}`);
+        this.canAdmin = adminCheck.data.result;
+      } catch (error) {
+        this.canAdmin = false;
+      }
+    },
     async fetchMembers() {
       const memberResults = await this.$http.get(("/club/members"), {
         clubId: this.$route.params.id,


### PR DESCRIPTION
Replaced 'isAdmin' with 'canAdmin' and added a checkAdmin method to determine admin privileges via an API call. Updated the mounted lifecycle hook to invoke the new admin check method alongside fetching members.