### PR TITLE
Refactor role checks to unify leadership roles

### DIFF
--- a/api/src/controllers/admin.controller.ts
+++ b/api/src/controllers/admin.controller.ts
@@ -112,7 +112,7 @@ class AdminController {
       place_id = parseInt(place_id);
     }
     const accessLevel = await this.memberService.getAccessLevel(session.id);
-    if (accessLevel.includes('leader')) {
+    if (accessLevel.includes('admin')) {
       try {
         await this.adminService.fireRole(
           parseInt(member_id),
@@ -168,7 +168,7 @@ class AdminController {
     const session = this.memberService.decryptSession(request, response);
     if (!session) return;
     const accessLevel = await this.memberService.getAccessLevel(session.id);
-    if (accessLevel.includes('leader')) {
+    if (accessLevel.includes('admin')) {
       const {member_id, role_id} = request.body;
       try {
         await this.adminService.hireRole(

--- a/api/src/controllers/admin.controller.ts
+++ b/api/src/controllers/admin.controller.ts
@@ -112,7 +112,7 @@ class AdminController {
       place_id = parseInt(place_id);
     }
     const accessLevel = await this.memberService.getAccessLevel(session.id);
-    if (accessLevel.includes('mayor')) {
+    if (accessLevel.includes('leader')) {
       try {
         await this.adminService.fireRole(
           parseInt(member_id),
@@ -168,7 +168,7 @@ class AdminController {
     const session = this.memberService.decryptSession(request, response);
     if (!session) return;
     const accessLevel = await this.memberService.getAccessLevel(session.id);
-    if (accessLevel.includes('mayor')) {
+    if (accessLevel.includes('leader')) {
       const {member_id, role_id} = request.body;
       try {
         await this.adminService.hireRole(

--- a/api/src/controllers/member.controller.ts
+++ b/api/src/controllers/member.controller.ts
@@ -151,7 +151,7 @@ class MemberController {
     if (!session) return;
     if (id !== undefined) {
       const admin = await this.memberService.getAccessLevel(session.id);
-      if (admin.includes('council') || admin.includes('security')) {
+      if (admin.includes('leader') || admin.includes('security')) {
         try {
           const roles = await this.memberService.getRoles(parseInt(id));
           response.status(200).json({roles});

--- a/api/src/services/block/block.service.ts
+++ b/api/src/services/block/block.service.ts
@@ -165,8 +165,7 @@ export class BlockService {
         return (
           [
             this.roleRepository.roleMap.Admin,
-            this.roleRepository.roleMap.CityMayor,
-            this.roleRepository.roleMap.DeputyMayor,
+            this.roleRepository.roleMap.ColonyRepresentative,
           ].includes(assignment.role_id) ||
           ([
             this.roleRepository.roleMap.ColonyLeader,
@@ -202,8 +201,7 @@ export class BlockService {
         return (
           [
             this.roleRepository.roleMap.Admin,
-            this.roleRepository.roleMap.CityMayor,
-            this.roleRepository.roleMap.DeputyMayor,
+            this.roleRepository.roleMap.ColonyRepresentative,
           ].includes(assignment.role_id) ||
           ([
             this.roleRepository.roleMap.ColonyLeader,

--- a/api/src/services/colony/colony.service.ts
+++ b/api/src/services/colony/colony.service.ts
@@ -171,8 +171,7 @@ export class ColonyService {
         return (
           [
             this.roleRepository.roleMap.Admin,
-            this.roleRepository.roleMap.CityMayor,
-            this.roleRepository.roleMap.DeputyMayor,
+            this.roleRepository.roleMap.ColonyRepresentative,
           ].includes(assignment.role_id) ||
           ([this.roleRepository.roleMap.ColonyLeader].includes(assignment.role_id) &&
             assignment.place_id === colonyId)

--- a/api/src/services/hood/hood.service.ts
+++ b/api/src/services/hood/hood.service.ts
@@ -153,8 +153,7 @@ export class HoodService {
         return (
           [
             this.roleRepository.roleMap.Admin,
-            this.roleRepository.roleMap.CityMayor,
-            this.roleRepository.roleMap.DeputyMayor,
+            this.roleRepository.roleMap.ColonyRepresentative,
           ].includes(assignment.role_id) ||
           ([
             this.roleRepository.roleMap.ColonyLeader,
@@ -183,8 +182,7 @@ export class HoodService {
         return (
           [
             this.roleRepository.roleMap.Admin,
-            this.roleRepository.roleMap.CityMayor,
-            this.roleRepository.roleMap.DeputyMayor,
+            this.roleRepository.roleMap.ColonyRepresentative,
           ].includes(assignment.role_id) ||
           ([
             this.roleRepository.roleMap.ColonyLeader,

--- a/api/src/services/member/member.service.ts
+++ b/api/src/services/member/member.service.ts
@@ -63,29 +63,17 @@ export class MemberService {
     ];
     return !!roleAssignments.find(assignment => ADMIN_ROLES.includes(assignment.role_id));
   }
-  
-  public async canMayor(memberId: number): Promise<boolean> {
+
+  public async canLeader(memberId: number): Promise<boolean> {
     const roleAssignments = await this.roleAssignmentRepository.getByMemberId(memberId);
     // Extracted admin roles into a constant for easy management
-    const MAYOR_ROLES = [
+    const LEADER_ROLES = [
       this.roleRepository.roleMap.Admin,
-      this.roleRepository.roleMap.CityMayor,
-      this.roleRepository.roleMap.DeputyMayor,
-    ];
-    return !!roleAssignments.find(assignment => MAYOR_ROLES.includes(assignment.role_id));
-  }
-  
-  public async canCouncil(memberId: number): Promise<boolean> {
-    const roleAssignments = await this.roleAssignmentRepository.getByMemberId(memberId);
-    // Extracted admin roles into a constant for easy management
-    const MAYOR_ROLES = [
-      this.roleRepository.roleMap.Admin,
-      this.roleRepository.roleMap.CityMayor,
-      this.roleRepository.roleMap.DeputyMayor,
       this.roleRepository.roleMap.ColonyLeader,
-      this.roleRepository.roleMap.CityCouncil,
+      this.roleRepository.roleMap.ColonyRepresentative,
+      this.roleRepository.roleMap.PlacesChief,
     ];
-    return !!roleAssignments.find(assignment => MAYOR_ROLES.includes(assignment.role_id));
+    return !!roleAssignments.find(assignment => LEADER_ROLES.includes(assignment.role_id));
   }
 
   public async canStaff(memberId: number): Promise<boolean> {
@@ -112,10 +100,9 @@ export class MemberService {
   }
 
   public async getAccessLevel(memberId: number): Promise<any> {
-    const mayor = await this.canMayor(memberId);
     const security = await this.canAdmin(memberId);
-    const council = await this.canCouncil(memberId);
     const roleAssignments = await this.roleAssignmentRepository.getByMemberId(memberId);
+    const leader = await this.canLeader(memberId);
     const admin = !!roleAssignments.find(
       assignment => assignment.role_id === this.roleRepository.roleMap.Admin,
     );
@@ -123,14 +110,11 @@ export class MemberService {
     if (admin) {
       accessLevel.push('admin');
     }
-    if (mayor) {
-      accessLevel.push('mayor');
-    }
     if (security) {
       accessLevel.push('security');
     }
-    if (council) {
-      accessLevel.push('council');
+    if (leader) {
+      accessLevel.push('leader');
     }
     return accessLevel;
   }

--- a/api/src/services/place/place.service.ts
+++ b/api/src/services/place/place.service.ts
@@ -47,6 +47,18 @@ export class PlaceService {
         return true;
       }
     }
+    if (slug === 'cityhall') {
+      if(
+        roleAssignments.find(assignment => {
+          return (
+            [
+              this.roleRepository.roleMap.CityCouncil,
+            ].includes(assignment.role_id)
+          );
+        })) {
+        return true;
+      }
+    }
     
     //check if admin even if there is no assigned roles for the place
     if (!placeRoleId) {

--- a/api/src/services/place/place.service.ts
+++ b/api/src/services/place/place.service.ts
@@ -97,7 +97,7 @@ export class PlaceService {
         return (
           [
             this.roleRepository.roleMap.Admin,
-            ...(slug !== 'mall' ? [this.roleRepository.roleMap.PlacesChief] : []),
+            this.roleRepository.roleMap.PlacesChief,
           ].includes(assignment.role_id) ||
         ([placeRoleId.owner].includes(assignment.role_id) &&
          assignment.place_id === placeId)

--- a/api/src/services/place/place.service.ts
+++ b/api/src/services/place/place.service.ts
@@ -55,8 +55,6 @@ export class PlaceService {
           return (
             [
               this.roleRepository.roleMap.Admin,
-              this.roleRepository.roleMap.CityMayor,
-              this.roleRepository.roleMap.DeputyMayor,
             ].includes(assignment.role_id)
           );
         })
@@ -72,8 +70,7 @@ export class PlaceService {
           return (
             [
               this.roleRepository.roleMap.Admin,
-              this.roleRepository.roleMap.CityMayor,
-              this.roleRepository.roleMap.DeputyMayor,
+              this.roleRepository.roleMap.PlacesChief,
             ].includes(assignment.role_id) ||
           ([
             placeRoleId.owner,
@@ -100,9 +97,7 @@ export class PlaceService {
         return (
           [
             this.roleRepository.roleMap.Admin,
-            this.roleRepository.roleMap.CityMayor,
-            this.roleRepository.roleMap.DeputyMayor,
-            this.roleRepository.roleMap.PlacesChief,
+            ...(slug !== 'mall' ? [this.roleRepository.roleMap.PlacesChief] : []),
           ].includes(assignment.role_id) ||
         ([placeRoleId.owner].includes(assignment.role_id) &&
          assignment.place_id === placeId)
@@ -337,6 +332,9 @@ export class PlaceService {
       personalclub: {
         owner: this.roleRepository.roleMap.ClubOwner,
         deputy: this.roleRepository.roleMap.ClubAssistant,
+      },
+      cityhall: {
+        owner: this.roleRepository.roleMap.CityCouncil,
       },
     };
     return roleId[slug];

--- a/spa/src/pages/admin/user/HireRoles.vue
+++ b/spa/src/pages/admin/user/HireRoles.vue
@@ -89,7 +89,7 @@ export default Vue.extend({
     },
   },
   mounted() {
-    if (!this.accessLevel.includes("mayor")) {
+    if (!this.accessLevel.includes("leader")) {
       this.$router.push({ name: "restrictedaccess" });
     }
     this.getRoleList();

--- a/spa/src/pages/admin/user/HireRoles.vue
+++ b/spa/src/pages/admin/user/HireRoles.vue
@@ -89,7 +89,7 @@ export default Vue.extend({
     },
   },
   mounted() {
-    if (!this.accessLevel.includes("leader")) {
+    if (!this.accessLevel.includes("admin")) {
       this.$router.push({ name: "restrictedaccess" });
     }
     this.getRoleList();

--- a/spa/src/pages/admin/user/SubMenu.vue
+++ b/spa/src/pages/admin/user/SubMenu.vue
@@ -27,7 +27,7 @@
          :to="{name: 'UserBanHistory'}">HISTORY</router-link>
       </div>
       <div class="w-full min-w-min text-center my-2"
-       v-else-if="isUserRoleRoute && (accessLevel.includes('council') || accessLevel.includes('security'))">
+       v-else-if="isUserRoleRoute && (accessLevel.includes('leader') || accessLevel.includes('security'))">
         <router-link class="btn-ui-inline mx-1 w-24"
          :to="{name: 'UserCurrentRoles'}">CURRENT</router-link>
         <router-link

--- a/spa/src/pages/admin/user/SubMenu.vue
+++ b/spa/src/pages/admin/user/SubMenu.vue
@@ -31,10 +31,10 @@
         <router-link class="btn-ui-inline mx-1 w-24"
          :to="{name: 'UserCurrentRoles'}">CURRENT</router-link>
         <router-link
-          v-if="accessLevel.includes('leader')"
+          v-if="accessLevel.includes('admin')"
           class="btn-ui-inline mx-1 w-24"
           :to="{name: 'UserHireRoles'}">HIRE</router-link>
-        <router-link v-if="accessLevel.includes('leader')" class="btn-ui-inline mx-1 w-24"
+        <router-link v-if="accessLevel.includes('admin')" class="btn-ui-inline mx-1 w-24"
          :to="{name: 'UserFireRoles'}">TERMINATE</router-link>
       </div>
       <div class="w-full min-w-min text-center my-2"

--- a/spa/src/pages/admin/user/SubMenu.vue
+++ b/spa/src/pages/admin/user/SubMenu.vue
@@ -31,10 +31,10 @@
         <router-link class="btn-ui-inline mx-1 w-24"
          :to="{name: 'UserCurrentRoles'}">CURRENT</router-link>
         <router-link
-          v-if="accessLevel.includes('mayor')"
+          v-if="accessLevel.includes('leader')"
           class="btn-ui-inline mx-1 w-24"
           :to="{name: 'UserHireRoles'}">HIRE</router-link>
-        <router-link v-if="accessLevel.includes('mayor')" class="btn-ui-inline mx-1 w-24"
+        <router-link v-if="accessLevel.includes('leader')" class="btn-ui-inline mx-1 w-24"
          :to="{name: 'UserFireRoles'}">TERMINATE</router-link>
       </div>
       <div class="w-full min-w-min text-center my-2"

--- a/spa/src/pages/world-browser/WorldBrowserTools.vue
+++ b/spa/src/pages/world-browser/WorldBrowserTools.vue
@@ -45,7 +45,7 @@
       </span>
       <span href=""
             class="btn-ui">Update</span>
-      <span v-show="$store.data.place.type !== 'shop'">
+      <span v-show="$store.data.place.type !== 'shop' && $store.data.place.slug !== 'cityhall'">
         <router-link :to="{ name: 'worldAccessRights' }"
                      class="btn-ui">Access Rights</router-link>
       </span>


### PR DESCRIPTION
Replace CityMayor and DeputyMayor roles with ColonyRepresentative across multiple services and introduce a canLeader method to streamline role checks for leadership, including the new PlacesChief role.