### PR TITLE
feat: decouple socket presence from X_ITE initialization

### DIFF
--- a/spa/.gitignore
+++ b/spa/.gitignore
@@ -1,3 +1,4 @@
 dist
 node_modules
 assets/object
+tests/.compiled

--- a/spa/package.json
+++ b/spa/package.json
@@ -7,7 +7,8 @@
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint",
     "dev": "vue-cli-service build --mode development --watch",
-    "dev-server": "nodemon --inspect=0.0.0.0:9230 -r dotenv/config server.js"
+    "dev-server": "nodemon --inspect=0.0.0.0:9230 -r dotenv/config server.js",
+    "test": "tsc --project tests/tsconfig.json && node tests/.compiled/tests/presence.test.js"
   },
   "dependencies": {
     "axios": "^0.23.0",

--- a/spa/server.js
+++ b/spa/server.js
@@ -87,22 +87,52 @@ io.on("connection", async function(socket) {
             socket.emit("JOIN:error", { reason: "invalid_token" });
             return;
         }
-        if (!data.presenceId) {
-            console.error("JOIN missing presenceId!");
-            socket.emit("JOIN:error", { reason: "missing_presence_id" });
+        const presenceId = data.presenceId;
+        const MAX_PRESENCE_ID_LENGTH = 128;
+        if (
+            typeof presenceId !== "string" ||
+            presenceId.length === 0 ||
+            presenceId.length > MAX_PRESENCE_ID_LENGTH
+        ) {
+            console.error("JOIN has invalid presenceId!");
+            socket.emit("JOIN:error", { reason: "invalid_presence_id" });
             return;
         }
 
-        const { room, presenceId } = data;
+        const { room } = data;
+        // memberId, username, and avatar are derived only from the verified
+        // JWT - never from client-supplied data - so presenceId can be
+        // freely client-chosen without letting a client impersonate another
+        // account's identity.
         const memberId = tokenData.id;
         const key = presenceKey(memberId, presenceId);
         const defaultPos = [0, 0, 0];
         const defaultRot = [0, 1, 0, 0];
+        const user = USERS.get(socket);
 
-        USERS.get(socket).avatar = tokenData.avatar;
-        USERS.get(socket).room = room;
-        USERS.get(socket).username = tokenData.username;
-        USERS.get(socket).presenceKey = key;
+        // Defensively leave any previously tracked room for this socket
+        // before joining the new one - guarantees one room per socket even
+        // if a client ever calls JOIN without a preceding unsubscribe.
+        if (user.room && user.room !== room) {
+            const oldPresence = user.presenceKey ? PRESENCE.get(user.presenceKey) : null;
+            socket.leave(user.room);
+            socket.to(user.room).emit("AV:del", {
+                id: socket.id,
+                memberId: oldPresence?.memberId,
+                presenceId: oldPresence?.presenceId,
+                username: user.username,
+            });
+            if (user.presenceKey && oldPresence?.socketId === socket.id) {
+                PRESENCE.delete(user.presenceKey);
+            }
+        }
+
+        const isNewPresence = !PRESENCE.has(key);
+
+        user.avatar = tokenData.avatar;
+        user.room = room;
+        user.username = tokenData.username;
+        user.presenceKey = key;
 
         PRESENCE.set(key, {
             memberId,
@@ -123,14 +153,18 @@ io.on("connection", async function(socket) {
         // against this by logical presence key, independent of readiness.
         socket.emit("ROOM_STATE", { room, presences: roomPresenceSnapshot(room) });
 
-        // inform other members of the room that someone joined
-        socket.to(room).emit("AV:new", {
-            id: socket.id,
-            memberId,
-            presenceId,
-            avatar: tokenData.avatar,
-            username: tokenData.username,
-        });
+        // Only announce a genuinely new presence - repeating JOIN for the
+        // same room/presence (e.g. a redundant client call) must not spam
+        // peers with another "someone joined" broadcast.
+        if (isNewPresence) {
+            socket.to(room).emit("AV:new", {
+                id: socket.id,
+                memberId,
+                presenceId,
+                avatar: tokenData.avatar,
+                username: tokenData.username,
+            });
+        }
 
         console.log(`User '${tokenData.username}' entered room ${room}`);
         webhookMessage(
@@ -238,20 +272,31 @@ io.on("connection", async function(socket) {
 
     socket.on("unsubscribe", () => {
         const user = USERS.get(socket);
-        const presence = user?.presenceKey ? PRESENCE.get(user.presenceKey) : null;
-        socket.leave(user.room);
-        socket.to(user.room).emit("AV:del", {
+        if (!user?.room) {
+            // Nothing to leave - e.g. unsubscribe called without a prior
+            // successful JOIN.
+            return;
+        }
+        const room = user.room;
+        const presence = user.presenceKey ? PRESENCE.get(user.presenceKey) : null;
+        socket.leave(room);
+        socket.to(room).emit("AV:del", {
             id: socket.id,
             memberId: presence?.memberId,
             presenceId: presence?.presenceId,
             username: user.username,
         });
-        if (user?.presenceKey) {
+        if (user.presenceKey) {
             PRESENCE.delete(user.presenceKey);
         }
+        // Clear so a later disconnect (without a rejoin in between) sees
+        // "no room" instead of stale room/presenceKey and re-announcing a
+        // departure that was already sent above.
+        user.room = null;
+        user.presenceKey = null;
 
-        console.log(`User '${user.username}' left ${user.room}`);
-        webhookMessage("System", `${user.username} left ${user.room}`);
+        console.log(`User '${user.username}' left ${room}`);
+        webhookMessage("System", `${user.username} left ${room}`);
     });
 
     //handle disconnection from the socket.

--- a/spa/server.js
+++ b/spa/server.js
@@ -303,12 +303,18 @@ io.on("connection", async function(socket) {
     socket.on("disconnect", function() {
         const user = USERS.get(socket);
         const presence = user?.presenceKey ? PRESENCE.get(user.presenceKey) : null;
-        io.to(user?.room).emit("AV:del", {
-            id: socket.id,
-            memberId: presence?.memberId,
-            presenceId: presence?.presenceId,
-            username: user?.username,
-        });
+        // Only announce a departure if this socket was still in a room. A
+        // socket that already unsubscribed has had user.room cleared (and its
+        // AV:del already sent there), so re-emitting here would broadcast to
+        // an undefined room - matches the guard used in the "AV" handler.
+        if (user?.room) {
+            io.to(user.room).emit("AV:del", {
+                id: socket.id,
+                memberId: presence?.memberId,
+                presenceId: presence?.presenceId,
+                username: user?.username,
+            });
+        }
         // Only remove the presence record if this socket is still the one
         // it's bound to - guards against a stale/delayed disconnect from an
         // old socket clobbering a newer connection for the same presence.

--- a/spa/server.js
+++ b/spa/server.js
@@ -12,6 +12,27 @@ const package = require("./package.json");
 const badwords = require("badwords-list");
 const USERS = new Map();
 
+// Authoritative presence state, keyed by the logical presence key
+// `memberId:presenceId` - never by socket id, which is replaceable
+// transport metadata. One entry per (member, tab); two tabs on the same
+// member get two entries.
+const PRESENCE = new Map();
+
+function presenceKey(memberId, presenceId) {
+    return `${memberId}:${presenceId}`;
+}
+
+function roomPresenceSnapshot(room) {
+    const snapshot = [];
+    for (const presence of PRESENCE.values()) {
+        if (presence.room === room) {
+            const { memberId, presenceId, socketId, username, avatar, pos, rot } = presence;
+            snapshot.push({ memberId, presenceId, socketId, username, avatar, pos, rot });
+        }
+    }
+    return snapshot;
+}
+
 function webhookMessage(from, message) {
     return;
     if (!process.env.CHAT_WEBHOOK_URL) return;
@@ -61,55 +82,76 @@ io.on("connection", async function(socket) {
 
     socket.on("JOIN", (data) => {
         const tokenData = validJwt(data.token);
-        if (tokenData) {
-            const { room } = data;
-            USERS.get(socket).avatar = tokenData.avatar;
-            USERS.get(socket).room = room;
-            USERS.get(socket).username = tokenData.username;
-
-            // inform other members of the room that someone joined
-            socket.to(room).emit("AV:new", {
-                id: socket.id,
-                avatar: tokenData.avatar,
-                username: tokenData.username,
-            });
-
-            socket.join(room);
-            // provide the new user with data about the current users in the room
-            const clientsInRoom = io.sockets.adapter.rooms.get(room);
-            for (const clientId of clientsInRoom) {
-                if (clientId === socket.id) continue;
-                const clientSocket = io.sockets.sockets.get(clientId);
-                const user = USERS.get(clientSocket);
-                if (user) {
-                    const { avatar, pos, rot, username } = user;
-                    socket.emit("AV:new", {
-                        avatar,
-                        id: clientId,
-                        username,
-                    });
-                    socket.emit("AV", {
-                        id: clientId,
-                        pos,
-                        rot,
-                    });
-                }
-            }
-
-            console.log(`User '${tokenData.username}' entered room ${room}`);
-            webhookMessage(
-                "System",
-                `${tokenData.username} entered room \`${room}\``
-            );
-        } else {
+        if (!tokenData) {
             console.error("invalid token!");
+            socket.emit("JOIN:error", { reason: "invalid_token" });
+            return;
         }
+        if (!data.presenceId) {
+            console.error("JOIN missing presenceId!");
+            socket.emit("JOIN:error", { reason: "missing_presence_id" });
+            return;
+        }
+
+        const { room, presenceId } = data;
+        const memberId = tokenData.id;
+        const key = presenceKey(memberId, presenceId);
+        const defaultPos = [0, 0, 0];
+        const defaultRot = [0, 1, 0, 0];
+
+        USERS.get(socket).avatar = tokenData.avatar;
+        USERS.get(socket).room = room;
+        USERS.get(socket).username = tokenData.username;
+        USERS.get(socket).presenceKey = key;
+
+        PRESENCE.set(key, {
+            memberId,
+            presenceId,
+            socketId: socket.id,
+            username: tokenData.username,
+            avatar: tokenData.avatar,
+            pos: defaultPos,
+            rot: defaultRot,
+            room,
+        });
+
+        socket.join(room);
+
+        // Give the joining client one authoritative snapshot of everyone
+        // currently in the room (including itself) instead of an ad-hoc
+        // AV:new/AV replay loop. Chat and the X_ITE avatar layer reconcile
+        // against this by logical presence key, independent of readiness.
+        socket.emit("ROOM_STATE", { room, presences: roomPresenceSnapshot(room) });
+
+        // inform other members of the room that someone joined
+        socket.to(room).emit("AV:new", {
+            id: socket.id,
+            memberId,
+            presenceId,
+            avatar: tokenData.avatar,
+            username: tokenData.username,
+        });
+
+        console.log(`User '${tokenData.username}' entered room ${room}`);
+        webhookMessage(
+            "System",
+            `${tokenData.username} entered room \`${room}\``
+        );
     });
 
     //handle avatar related calls.
     socket.on("AV", function(msg) {
         msg.id = socket.id;
         const user = USERS.get(socket);
+        if (user?.presenceKey) {
+            const presence = PRESENCE.get(user.presenceKey);
+            if (presence) {
+                msg.memberId = presence.memberId;
+                msg.presenceId = presence.presenceId;
+                if (msg.pos) presence.pos = msg.pos;
+                if (msg.rot) presence.rot = msg.rot;
+            }
+        }
         if (user?.room) {
             socket.to(user.room).emit("AV", msg);
         }
@@ -196,11 +238,17 @@ io.on("connection", async function(socket) {
 
     socket.on("unsubscribe", () => {
         const user = USERS.get(socket);
+        const presence = user?.presenceKey ? PRESENCE.get(user.presenceKey) : null;
         socket.leave(user.room);
         socket.to(user.room).emit("AV:del", {
             id: socket.id,
+            memberId: presence?.memberId,
+            presenceId: presence?.presenceId,
             username: user.username,
         });
+        if (user?.presenceKey) {
+            PRESENCE.delete(user.presenceKey);
+        }
 
         console.log(`User '${user.username}' left ${user.room}`);
         webhookMessage("System", `${user.username} left ${user.room}`);
@@ -209,10 +257,19 @@ io.on("connection", async function(socket) {
     //handle disconnection from the socket.
     socket.on("disconnect", function() {
         const user = USERS.get(socket);
+        const presence = user?.presenceKey ? PRESENCE.get(user.presenceKey) : null;
         io.to(user?.room).emit("AV:del", {
             id: socket.id,
-            username: user.username,
+            memberId: presence?.memberId,
+            presenceId: presence?.presenceId,
+            username: user?.username,
         });
+        // Only remove the presence record if this socket is still the one
+        // it's bound to - guards against a stale/delayed disconnect from an
+        // old socket clobbering a newer connection for the same presence.
+        if (user?.presenceKey && presence?.socketId === socket.id) {
+            PRESENCE.delete(user.presenceKey);
+        }
         USERS.delete(socket);
         console.log(`User '${user?.username}' disconnected`);
     });

--- a/spa/src/components/Chat.vue
+++ b/spa/src/components/Chat.vue
@@ -742,7 +742,14 @@ export default Vue.extend<ChatData, ChatMethods, ChatComputed, Record<string, an
     },
     startNewChat(): void {
       this.messages = [];
-      this.users = [];
+      // Deliberately does NOT reset `this.users`: the roster is owned
+      // exclusively by the presenceStore subscription (subscribeToPresence),
+      // which drains the authoritative ROOM_STATE snapshot at mount and stays
+      // reconciled via live add/update/remove events. Chat remounts fresh per
+      // place load (v-if="chatReady"), so `users` already starts empty for a
+      // new room - there is nothing to clear here. Clearing it wiped the
+      // just-drained roster, so a stationary pre-existing occupant vanished
+      // until they moved or someone new joined.
       this.canInteractWithObject = false;
       if(this.$store.data.place.member_id === this.$store.data.user.id) {
         this.canModify = true;

--- a/spa/src/components/Chat.vue
+++ b/spa/src/components/Chat.vue
@@ -253,6 +253,7 @@
 
 import Vue from 'vue';
 import { debugMsg } from '@/helpers';
+import { Presence, presenceKey } from '@/presence';
 import UserMenu from './UserMenu.vue';
 
 interface ChatData {
@@ -318,6 +319,7 @@ interface ChatData {
   virtualPetDefault: any[];
   entryMessageCode: number;
   selectedId: any;
+  unsubscribePresence: (() => void) | null;
 }
 
 interface ChatMethods {
@@ -335,6 +337,9 @@ export default Vue.extend<ChatData, ChatMethods, ChatComputed, Record<string, an
   },
   props: {
     place: {
+      default: null,
+    },
+    presenceStore: {
       default: null,
     },
     sharedEvent: {
@@ -411,6 +416,7 @@ export default Vue.extend<ChatData, ChatMethods, ChatComputed, Record<string, an
       virtualPetDefault: [],
       entryMessageCode: new Date().getTime(),
       selectedId: null,
+      unsubscribePresence: null,
     };
   },
   directives: {
@@ -1051,6 +1057,57 @@ export default Vue.extend<ChatData, ChatMethods, ChatComputed, Record<string, an
         }
       }
     },
+    /**
+     * The user roster is driven by the shared presenceStore (same source
+     * X_ITE's avatar renderer reads from), not raw AV:new/AV:del socket
+     * events directly - this is what lets the roster be correct whether or
+     * not X_ITE has initialized yet, and keeps both consumers reconciled by
+     * the same logical presence key instead of independently tracking ids.
+     */
+    isSelf(presence: Presence): boolean {
+      return `${presence.memberId}` === `${this.$store.data.user.id}` &&
+        presence.presenceId === this.$socket.presenceId;
+    },
+    addRosterEntry(presence: Presence): void {
+      if (this.isSelf(presence)) return;
+      const key = presenceKey(presence.memberId, presence.presenceId);
+      if (this.users.some(u => u.id === key)) return;
+      this.systemMessage(presence.username + " has entered.");
+      const rosterEntry = { id: key, username: presence.username, avatar: presence.avatar };
+      this.users.push(rosterEntry);
+      this.isMember3D(rosterEntry);
+    },
+    updateRosterEntry(presence: Presence): void {
+      if (this.isSelf(presence)) return;
+      const key = presenceKey(presence.memberId, presence.presenceId);
+      const existing = this.users.find(u => u.id === key);
+      if (!existing) {
+        this.addRosterEntry(presence);
+        return;
+      }
+      existing.username = presence.username;
+      existing.avatar = presence.avatar;
+    },
+    removeRosterEntry(key: string, presence?: Presence): void {
+      const wasPresent = this.users.some(u => u.id === key);
+      this.users = this.users.filter((u) => u.id !== key);
+      if (wasPresent) {
+        this.systemMessage(`${presence?.username || "Someone"} has left.`);
+      }
+      const index = this.worldMembers.indexOf(presence?.username);
+      if (index > -1) {
+        this.worldMembers.splice(index, 1);
+      }
+    },
+    subscribeToPresence(): void {
+      if (!this.presenceStore) return;
+      this.presenceStore.all().forEach(presence => this.addRosterEntry(presence));
+      this.unsubscribePresence = this.presenceStore.subscribe(event => {
+        if (event.type === "add") this.addRosterEntry(event.presence);
+        if (event.type === "update") this.updateRosterEntry(event.presence);
+        if (event.type === "remove") this.removeRosterEntry(event.key, event.presence);
+      });
+    },
     startSocketListeners(): void {
       this.$socket.on("CHAT", data => {
         this.debugMsg("chat message received...", data);
@@ -1063,19 +1120,6 @@ export default Vue.extend<ChatData, ChatMethods, ChatComputed, Record<string, an
             this.textToSpeech(data);
           }
         }
-      });
-      this.$socket.on("AV:del", event => {
-        this.systemMessage(event.username + " has left.");
-        this.users = this.users.filter((u) => u.id !== event.id);
-        let index = this.worldMembers.indexOf(event.username);
-        if(index > -1){
-          this.worldMembers.splice(index, 1);
-        }
-      });
-      this.$socket.on("AV:new", event => {
-        this.systemMessage(event.username + " has entered.");
-        this.users.push(event);
-        this.isMember3D(event);
       });
       this.$socket.on("disconnect", () => {
         this.systemMessage("Chat server disconnected. Please refresh to reconnect.");
@@ -1198,10 +1242,12 @@ export default Vue.extend<ChatData, ChatMethods, ChatComputed, Record<string, an
   },
   beforeDestroy() {
     this.setTimers(false);
+    if (this.unsubscribePresence) this.unsubscribePresence();
   },
   mounted() {
     this.debugMsg("starting chat page...");
     this.startSocketListeners();
+    this.subscribeToPresence();
     if (this.$store.data.place && this.connected) {
       this.chatEnabled = true;
       this.startNewChat();

--- a/spa/src/components/Chat.vue
+++ b/spa/src/components/Chat.vue
@@ -253,7 +253,7 @@
 
 import Vue from 'vue';
 import { debugMsg } from '@/helpers';
-import { Presence, presenceKey } from '@/presence';
+import { Presence, presenceKey, isSelfPresence } from '@/presence';
 import UserMenu from './UserMenu.vue';
 
 interface ChatData {
@@ -1065,8 +1065,7 @@ export default Vue.extend<ChatData, ChatMethods, ChatComputed, Record<string, an
      * the same logical presence key instead of independently tracking ids.
      */
     isSelf(presence: Presence): boolean {
-      return `${presence.memberId}` === `${this.$store.data.user.id}` &&
-        presence.presenceId === this.$socket.presenceId;
+      return isSelfPresence(presence, this.$store.data.user.id, this.$socket.presenceId);
     },
     addRosterEntry(presence: Presence): void {
       if (this.isSelf(presence)) return;
@@ -1109,34 +1108,50 @@ export default Vue.extend<ChatData, ChatMethods, ChatComputed, Record<string, an
       });
     },
     startSocketListeners(): void {
-      this.$socket.on("CHAT", data => {
-        this.debugMsg("chat message received...", data);
-        if(this.virtualPet){
-          this.petResponse(data);
+      // Chat remounts fresh on every place load (v-if="chatReady"), so
+      // these handlers must be removable on teardown - bound to named
+      // instance methods rather than anonymous inline callbacks, and
+      // removed in beforeDestroy(), so repeated place navigation doesn't
+      // accumulate one more set of listeners on the shared socket for
+      // every place ever visited this session.
+      this.$socket.on("CHAT", this.onChatMessage);
+      this.$socket.on("disconnect", this.onSocketDisconnect);
+      this.$socket.on("update-object", this.onUpdateObjectEvent);
+      this.$socket.on("moderation_event", this.onModerationEvent);
+    },
+    stopSocketListeners(): void {
+      this.$socket.off("CHAT", this.onChatMessage);
+      this.$socket.off("disconnect", this.onSocketDisconnect);
+      this.$socket.off("update-object", this.onUpdateObjectEvent);
+      this.$socket.off("moderation_event", this.onModerationEvent);
+    },
+    onChatMessage(data): void {
+      this.debugMsg("chat message received...", data);
+      if(this.virtualPet){
+        this.petResponse(data);
+      }
+      if(this.blockedMembers.includes(data.username) === false){
+        this.messages.push(data);
+        if(this.tts){
+          this.textToSpeech(data);
         }
-        if(this.blockedMembers.includes(data.username) === false){
-          this.messages.push(data);
-          if(this.tts){
-            this.textToSpeech(data);
-          }
-        }
-      });
-      this.$socket.on("disconnect", () => {
-        this.systemMessage("Chat server disconnected. Please refresh to reconnect.");
-        this.setTimers(false);
-        this.chatEnabled = false;
-      });
-      this.$socket.on("update-object", (object) => {
-        if([object.member_username, object.buyer_username].includes(this.$store.data.user.username) || 
-          [object.member_username, object.buyer_username].includes(this.username)){
-          this.updateObjectLists(object);
-        }
-      });
-      this.$socket.on("moderation_event", data => {
-        if(data.data.event === 'delete-message') {
-          this.deleteMessageFromLive(data.data.messageID);
-        }
-      });
+      }
+    },
+    onSocketDisconnect(): void {
+      this.systemMessage("Chat server disconnected. Please refresh to reconnect.");
+      this.setTimers(false);
+      this.chatEnabled = false;
+    },
+    onUpdateObjectEvent(object): void {
+      if([object.member_username, object.buyer_username].includes(this.$store.data.user.username) ||
+        [object.member_username, object.buyer_username].includes(this.username)){
+        this.updateObjectLists(object);
+      }
+    },
+    onModerationEvent(data): void {
+      if(data.data.event === 'delete-message') {
+        this.deleteMessageFromLive(data.data.messageID);
+      }
     },
     dropObject() {
       this.$emit("drop-object", this.objectId);
@@ -1243,6 +1258,7 @@ export default Vue.extend<ChatData, ChatMethods, ChatComputed, Record<string, an
   beforeDestroy() {
     this.setTimers(false);
     if (this.unsubscribePresence) this.unsubscribePresence();
+    this.stopSocketListeners();
   },
   mounted() {
     this.debugMsg("starting chat page...");

--- a/spa/src/join-protocol.ts
+++ b/spa/src/join-protocol.ts
@@ -1,0 +1,66 @@
+/**
+ * Confirmed-JOIN protocol, kept dependency-free (no `@/` aliased imports)
+ * so it can be unit-tested directly under plain Node/tsc without needing
+ * webpack's module resolution.
+ */
+
+/** Minimal shape `joinRoomOverSocket` needs - satisfied by a real socket.io
+ * Socket, and by a plain Node EventEmitter in tests. */
+export interface EmitterLike {
+  on(event: string, callback: (...args: any[]) => void): any;
+  off(event: string, callback: (...args: any[]) => void): any;
+  emit(event: string, ...args: any[]): any;
+}
+
+export const DEFAULT_JOIN_TIMEOUT_MS = 10000;
+
+/**
+ * Emits JOIN and waits for the server's authoritative confirmation - either
+ * a ROOM_STATE for the room we asked to join, or an explicit JOIN:error.
+ * Resolving merely because JOIN was emitted (the previous behavior) let
+ * Chat/room-ready state flip to "ready" even on an invalid token or a
+ * dropped request; this makes readiness conditional on a real server
+ * response, with a timeout so a lost response can't hang forever.
+ */
+export function joinRoomOverSocket(
+  socket: EmitterLike,
+  roomId: string | number,
+  token: string,
+  presenceId: string,
+  timeoutMs: number = DEFAULT_JOIN_TIMEOUT_MS,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+
+    const cleanup = () => {
+      socket.off("ROOM_STATE", onRoomState);
+      socket.off("JOIN:error", onError);
+      clearTimeout(timer);
+    };
+    const onRoomState = (event: { room?: string | number }) => {
+      if (settled) return;
+      // A ROOM_STATE for a different room is a stale/unrelated response
+      // (e.g. from a join this one superseded) - not confirmation of ours.
+      if (`${event?.room}` !== `${roomId}`) return;
+      settled = true;
+      cleanup();
+      resolve();
+    };
+    const onError = (event: { reason?: string }) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(new Error(`JOIN failed: ${event?.reason || "unknown"}`));
+    };
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(new Error("JOIN timed out waiting for server confirmation"));
+    }, timeoutMs);
+
+    socket.on("ROOM_STATE", onRoomState);
+    socket.on("JOIN:error", onError);
+    socket.emit("JOIN", { room: roomId, token, presenceId });
+  });
+}

--- a/spa/src/pages/world-browser/WorldBrowserPage.vue
+++ b/spa/src/pages/world-browser/WorldBrowserPage.vue
@@ -16,8 +16,9 @@
     <div class="flex flex-none h-1/3 bg-chat">
       <chat
         ref="chat"
-        v-if="loaded"
+        v-if="chatReady"
         :place="place"
+        :presence-store="presenceStore"
         :shared-event="sharedEvent"
         :shared-objects="sharedObjects"
         :clickId="clickId"
@@ -42,6 +43,7 @@ import {
   debugMsg,
   environment,
 } from "@/helpers";
+import { PresenceStore, Presence, presenceKey } from "@/presence";
 import { WorldBrowserData } from "./world-browser-data.interface";
 
 export default Vue.extend({
@@ -50,6 +52,8 @@ export default Vue.extend({
   data: (): WorldBrowserData => {
     return {
       loaded: false,
+      chatReady: false,
+      presenceStore: new PresenceStore(),
       worldsData: worldDataJson,
       avatarsData: avatarsDataJson,
       browser: null,
@@ -220,9 +224,13 @@ export default Vue.extend({
     },
     async loadAndJoinPlace(): Promise<void> {
       this.loaded = false;
+      this.chatReady = false;
       this.force2d = false;
 
       if (this.$store.data.place) this.$socket.leaveRoom(this.$store.data.place.id);
+      // Fresh presence state per place - nothing from the previous room's
+      // roster/avatars should leak into the one we're about to join.
+      this.presenceStore = new PresenceStore();
       await this.getPlace();
 
       if(this.$store.data.place.slug === "clubdir"){
@@ -239,10 +247,19 @@ export default Vue.extend({
         const browser = X3D.getBrowser(this.browser);
         browser.replaceWorld(null);
       }
+
+      // Room membership (JOIN) and Chat readiness no longer wait on X_ITE -
+      // only avatar rendering needs the 3D scene to exist. AV/AV:new/AV:del
+      // events for this room can now arrive before X_ITE initializes; they
+      // flow into presenceStore (see startSocketListeners) and are drained
+      // into the scene once it's ready (see startAvatarRenderer).
+      await this.joinPlace();
+      this.chatReady = true;
+
       if(this.$store.data.view3d && !this.force2d) {
         const browser = await this.startX3D();
-        this.loaded = true;
         this.startX3DListeners(browser);
+        this.loaded = true;
       } else {
 
         if(this.$store.data.place.type === "shop"){
@@ -260,16 +277,19 @@ export default Vue.extend({
         }
         this.loaded = true;
       }
-      this.joinPlace();
     },
     async unloadPlace(): Promise<void> {
       if (this.$store.data.place) this.$socket.leaveRoom(this.$store.data.place.id);
+      this.presenceStore = new PresenceStore();
       const browser = X3D.getBrowser(this.browser);
       browser.replaceWorld(null);
     },
     async joinPlace(): Promise<void> {
       await this.$socket.joinRoom(this.$store.data.place.id, this.$store.data.user.token);
       this.debugMsg("joined room success", this.$store.data.place.id);
+    },
+    /** Announces our own current viewpoint once X_ITE has one to report. */
+    sendInitialViewpoint(): void {
       if(this.$store.data.view3d){
         const { viewpointPosition, viewpointOrientation } = X3D.getBrowser(this.browser);
         this.$socket.emit("AV", {
@@ -286,7 +306,7 @@ export default Vue.extend({
               viewpointOrientation.angle,
             ],
           },
-        });       
+        });
       }
     },
     moveObject(objectId): void {
@@ -393,7 +413,15 @@ export default Vue.extend({
         });
       }
     },
-    async onAvatarAdded(event): Promise<void> {
+    /**
+     * Renders a presence's avatar for the first time. Called both when
+     * draining presenceStore at X_ITE-ready time and for live "add" events
+     * that arrive afterward - either way the presence object already
+     * carries whatever transform is currently known, so there's no need to
+     * wait for a separate "moved" event to position it correctly.
+     */
+    async renderPresenceAdded(presence: Presence): Promise<void> {
+      const key = presenceKey(presence.memberId, presence.presenceId);
       const ROTATE180 = new X3D.SFRotation(0, 1, 0, Math.PI);
 
       const unique = (prefix) => {
@@ -425,101 +453,119 @@ export default Vue.extend({
 
       const browser = X3D.getBrowser(this.browser);
 
-      if (!this.users[event.id]) {
-        this.users[event.id] = {};
+      if (!this.users[key]) {
+        this.users[key] = {};
       }
 
-      if (
-        !this.users[event.id].loading &&
-        !this.users[event.id].loaded
-      ) {
-        const { directory, filename } = event.avatar;
-        const avURL = `/assets/avatars/${directory}/${filename}`;
+      if (this.users[key].loading || this.users[key].loaded) {
+        return;
+      }
 
-        this.users[event.id].loading = true;
-        loadInlineAsync(browser, avURL).then((avInline) => {
-          const uniqueID = unique("Av-");
-          browser.currentScene.updateImportedNode(avInline, "Avatar", uniqueID);
-          const avImport = browser.currentScene.getImportedNode(uniqueID);
-          browser.currentScene.addRootNode(avInline);
-          this.users[event.id].loading = false;
-          this.users[event.id].loaded = true;
-          this.users[event.id]["inline"] = avInline;
-          this.users[event.id]["import"] = avImport;
+      if (presence.pos || presence.rot) {
+        this.users[key].transform = {
+          pos: presence.pos,
+          rot: presence.rot,
+        };
+      }
 
-          if (this.users[event.id]["inline"]) {
-            if (
-              this.users[event.id].transform &&
-              this.users[event.id].transform.pos
-            ) {
-              this.users[event.id]["import"].set_position = new X3D.SFVec3f(
-                ...this.users[event.id].transform.pos,
-              );
-            }
-            if (
-              this.users[event.id].transform &&
-              this.users[event.id].transform.rot
-            ) {
-              this.users[event.id]["import"].rotation = ROTATE180.multiply(
-                new X3D.SFRotation(...this.users[event.id].transform.rot),
-              );
-            }
+      const { directory, filename } = presence.avatar;
+      const avURL = `/assets/avatars/${directory}/${filename}`;
+
+      this.users[key].loading = true;
+      loadInlineAsync(browser, avURL).then((avInline) => {
+        const uniqueID = unique("Av-");
+        browser.currentScene.updateImportedNode(avInline, "Avatar", uniqueID);
+        const avImport = browser.currentScene.getImportedNode(uniqueID);
+        browser.currentScene.addRootNode(avInline);
+        this.users[key].loading = false;
+        this.users[key].loaded = true;
+        this.users[key]["inline"] = avInline;
+        this.users[key]["import"] = avImport;
+
+        if (this.users[key]["inline"]) {
+          if (
+            this.users[key].transform &&
+            this.users[key].transform.pos
+          ) {
+            this.users[key]["import"].set_position = new X3D.SFVec3f(
+              ...this.users[key].transform.pos,
+            );
           }
-        });
-      }
+          if (
+            this.users[key].transform &&
+            this.users[key].transform.rot
+          ) {
+            this.users[key]["import"].rotation = ROTATE180.multiply(
+              new X3D.SFRotation(...this.users[key].transform.rot),
+            );
+          }
+        }
+      });
     },
-    onAvatarMoved(event): void {
+    /** Updates an already-known presence's rendered position/rotation. */
+    renderPresenceUpdated(presence: Presence): void {
+      const key = presenceKey(presence.memberId, presence.presenceId);
       const ROTATE180 = new X3D.SFRotation(0, 1, 0, Math.PI);
-      const browser = X3D.getBrowser(this.browser);
 
-      if (!this.users[event.id]) {
-        this.users[event.id] = {};
+      if (!this.users[key]) {
+        // An update arrived before this presence was ever added (e.g. a
+        // transform update racing the initial render) - render it fresh
+        // instead of silently dropping it.
+        this.renderPresenceAdded(presence);
+        return;
       }
 
-      if (!this.users[event.id].transform) {
-        this.users[event.id].transform = {};
+      if (!this.users[key].transform) {
+        this.users[key].transform = {};
       }
 
-      if (event.pos) {
-        this.users[event.id].transform.pos = event.pos;
+      if (presence.pos) {
+        this.users[key].transform.pos = presence.pos;
       }
-      if (event.rot) {
-        this.users[event.id].transform.rot = event.rot;
+      if (presence.rot) {
+        this.users[key].transform.rot = presence.rot;
       }
 
-      if (this.users[event.id]["inline"]) {
-        if (this.users[event.id].transform.pos) {
-          this.users[event.id]["import"].set_position = new X3D.SFVec3f(
-            ...this.users[event.id].transform.pos,
+      if (this.users[key]["inline"]) {
+        if (this.users[key].transform.pos) {
+          this.users[key]["import"].set_position = new X3D.SFVec3f(
+            ...this.users[key].transform.pos,
           );
         }
-        if (this.users[event.id].transform.rot) {
-          this.users[event.id]["import"].rotation = ROTATE180.multiply(
-            new X3D.SFRotation(...this.users[event.id].transform.rot),
+        if (this.users[key].transform.rot) {
+          this.users[key]["import"].rotation = ROTATE180.multiply(
+            new X3D.SFRotation(...this.users[key].transform.rot),
           );
-        }
-
-        if (typeof event.gesture === "number") {
-          this.users[event.id]["import"][
-            `set_gesture${  event.gesture.toString()}`
-          ] = browser.getCurrentTime();
         }
       }
     },
-    onAvatarRemoved(event): void {
-      const { id } = event;
+    /** Removes a presence's rendered avatar, if it was ever rendered. */
+    renderPresenceRemoved(key: string): void {
+      if (!this.users[key]) return;
 
-      if (this.users[id].inline) {
+      if (this.users[key].inline) {
         X3D.getBrowser(this.browser)
           .currentScene
-          .removeRootNode(this.users[id].inline);
+          .removeRootNode(this.users[key].inline);
       }
 
-      if (this.users[id].import) {
-        this.users[id].import.dispose();
+      if (this.users[key].import) {
+        this.users[key].import.dispose();
       }
 
-      delete this.users[id];
+      delete this.users[key];
+    },
+    /**
+     * Gestures are momentary triggers, not persistent state, so they don't
+     * belong in presenceStore's latest-state model - they're only ever
+     * forwarded live, and simply dropped if the avatar isn't rendered yet
+     * rather than buffered and replayed once it is.
+     */
+    applyGesture(key: string, gesture: number): void {
+      const avatar = this.users[key];
+      if (!avatar || !avatar.loaded || !avatar.import) return;
+      avatar.import[`set_gesture${gesture.toString()}`] =
+        X3D.getBrowser(this.browser).getCurrentTime();
     },
     onSharedEvent(event): void {
       for (const node of this.eventNodeMap.get(event.name)) {
@@ -549,6 +595,40 @@ export default Vue.extend({
         const objectInstanceResponse = await this.$http.get(`/place/${  this.$store.data.place.id 
         }/object_instance`);
         this.sharedObjects = objectInstanceResponse.data.object_instance;
+      }
+    },
+    /**
+     * Authoritative snapshot of who's in the room right now, sent once on
+     * JOIN. Reconciling (rather than blindly appending) means this same
+     * handler can be reused as-is if a future reconnect PR re-sends
+     * ROOM_STATE to resync after a drop.
+     */
+    onRoomState(event: { room: string | number; presences: Presence[] }): void {
+      this.presenceStore.reconcile(event.presences);
+    },
+    /** A peer joined the room - renderer-independent, may run before X_ITE exists. */
+    onPresenceJoined(event): void {
+      if (typeof event.memberId === "undefined" || !event.presenceId) return;
+      this.presenceStore.upsert({
+        memberId: event.memberId,
+        presenceId: event.presenceId,
+        socketId: event.id,
+        username: event.username,
+        avatar: event.avatar,
+      });
+    },
+    /** A peer left the room - removes them from the authoritative store. */
+    onPresenceLeft(event): void {
+      if (typeof event.memberId === "undefined" || !event.presenceId) return;
+      this.presenceStore.remove(presenceKey(event.memberId, event.presenceId));
+    },
+    /** A peer moved - updates the store; gestures are forwarded live only. */
+    onPresenceMoved(event): void {
+      if (typeof event.memberId === "undefined" || !event.presenceId) return;
+      const key = presenceKey(event.memberId, event.presenceId);
+      this.presenceStore.updateTransform(key, event.pos, event.rot);
+      if (typeof event.gesture === "number") {
+        this.applyGesture(key, event.gesture);
       }
     },
     onVersion(event: { version: string }): void {
@@ -735,12 +815,31 @@ export default Vue.extend({
         }
       });
       this.$socket.on("SO", event => this.onSharedObjectEvent(event));
+      // Presence/room-membership events are renderer-independent and must
+      // be wired up here (mounted once), not gated behind X_ITE - they can
+      // arrive as soon as JOIN succeeds, before any 3D scene exists.
+      this.$socket.on("ROOM_STATE", event => this.onRoomState(event));
+      this.$socket.on("AV:new", event => this.onPresenceJoined(event));
+      this.$socket.on("AV:del", event => this.onPresenceLeft(event));
+      this.$socket.on("AV", event => this.onPresenceMoved(event));
     },
+    /** SE (shared events) only makes sense once an X_ITE scene exists. */
     start3DSocketListeners(): void {
-      this.$socket.on("AV", event => this.onAvatarMoved(event));
-      this.$socket.on("AV:del", event => this.onAvatarRemoved(event));
-      this.$socket.on("AV:new", event => this.onAvatarAdded(event));
       this.$socket.on("SE", event => this.onSharedEvent(event));
+    },
+    /**
+     * Drains whatever presence state already accumulated in presenceStore
+     * before X_ITE was ready, then subscribes for live updates. A presence
+     * that both joined and left before this ever ran is simply never
+     * rendered - it was removed from the store before `all()` was called.
+     */
+    startAvatarRenderer(): void {
+      this.presenceStore.all().forEach(presence => this.renderPresenceAdded(presence));
+      this.presenceStore.subscribe(event => {
+        if (event.type === "add") this.renderPresenceAdded(event.presence);
+        if (event.type === "update") this.renderPresenceUpdated(event.presence);
+        if (event.type === "remove") this.renderPresenceRemoved(event.key);
+      });
     },
     async startX3D(): Promise<any> {
       if (!this.browser) {
@@ -801,7 +900,9 @@ export default Vue.extend({
 
       this.startSharedEvents();
       this.start3DSocketListeners();
+      this.startAvatarRenderer();
       this.loaded = true;
+      this.sendInitialViewpoint();
     },
   },
   computed: {

--- a/spa/src/pages/world-browser/WorldBrowserPage.vue
+++ b/spa/src/pages/world-browser/WorldBrowserPage.vue
@@ -43,7 +43,7 @@ import {
   debugMsg,
   environment,
 } from "@/helpers";
-import { PresenceStore, Presence, presenceKey } from "@/presence";
+import { PresenceStore, Presence, presenceKey, isSelfPresence } from "@/presence";
 import { WorldBrowserData } from "./world-browser-data.interface";
 
 export default Vue.extend({
@@ -54,6 +54,8 @@ export default Vue.extend({
       loaded: false,
       chatReady: false,
       presenceStore: new PresenceStore(),
+      loadGeneration: 0,
+      sharedEventListenerRegistered: false,
       worldsData: worldDataJson,
       avatarsData: avatarsDataJson,
       browser: null,
@@ -223,15 +225,24 @@ export default Vue.extend({
       }
     },
     async loadAndJoinPlace(): Promise<void> {
+      // Bumped once per call, so a load superseded by a later one (rapid
+      // repeated navigation) can tell its own now-stale continuations not
+      // to touch state a newer load already owns.
+      const generation = ++this.loadGeneration;
+
       this.loaded = false;
       this.chatReady = false;
       this.force2d = false;
 
       if (this.$store.data.place) this.$socket.leaveRoom(this.$store.data.place.id);
-      // Fresh presence state per place - nothing from the previous room's
-      // roster/avatars should leak into the one we're about to join.
+      // Fresh presence state and avatar tracking per place - nothing from
+      // the previous room's roster/avatars should leak into the one we're
+      // about to join, and stale `loading`/`loaded` flags for a presence
+      // key seen in a previous room must not suppress a real render here.
       this.presenceStore = new PresenceStore();
+      this.users = {};
       await this.getPlace();
+      if (this.loadGeneration !== generation) return;
 
       if(this.$store.data.place.slug === "clubdir"){
         this.force2d = true;
@@ -253,11 +264,18 @@ export default Vue.extend({
       // events for this room can now arrive before X_ITE initializes; they
       // flow into presenceStore (see startSocketListeners) and are drained
       // into the scene once it's ready (see startAvatarRenderer).
-      await this.joinPlace();
+      try {
+        await this.joinPlace();
+      } catch (err) {
+        console.error("Failed to join place:", err);
+        return;
+      }
+      if (this.loadGeneration !== generation) return;
       this.chatReady = true;
 
       if(this.$store.data.view3d && !this.force2d) {
         const browser = await this.startX3D();
+        if (this.loadGeneration !== generation) return;
         this.startX3DListeners(browser);
         this.loaded = true;
       } else {
@@ -279,10 +297,14 @@ export default Vue.extend({
       }
     },
     async unloadPlace(): Promise<void> {
+      ++this.loadGeneration;
       if (this.$store.data.place) this.$socket.leaveRoom(this.$store.data.place.id);
       this.presenceStore = new PresenceStore();
-      const browser = X3D.getBrowser(this.browser);
-      browser.replaceWorld(null);
+      this.users = {};
+      if (this.browser) {
+        const browser = X3D.getBrowser(this.browser);
+        browser.replaceWorld(null);
+      }
     },
     async joinPlace(): Promise<void> {
       await this.$socket.joinRoom(this.$store.data.place.id, this.$store.data.user.token);
@@ -473,6 +495,14 @@ export default Vue.extend({
 
       this.users[key].loading = true;
       loadInlineAsync(browser, avURL).then((avInline) => {
+        // The presence may have left (authoritative reconciliation removed
+        // it) or already been rendered by a racing call while this model
+        // was in flight - in either case `this.users[key]` is no longer the
+        // same "still loading" entry we started with, so the completed
+        // model must never be attached to the scene.
+        if (!this.users[key] || this.users[key].loading !== true) {
+          return;
+        }
         const uniqueID = unique("Av-");
         browser.currentScene.updateImportedNode(avInline, "Avatar", uniqueID);
         const avImport = browser.currentScene.getImportedNode(uniqueID);
@@ -499,6 +529,10 @@ export default Vue.extend({
               new X3D.SFRotation(...this.users[key].transform.rot),
             );
           }
+        }
+      }).catch(() => {
+        if (this.users[key]) {
+          this.users[key].loading = false;
         }
       });
     },
@@ -604,6 +638,10 @@ export default Vue.extend({
      * ROOM_STATE to resync after a drop.
      */
     onRoomState(event: { room: string | number; presences: Presence[] }): void {
+      // A ROOM_STATE for a room we're no longer in (e.g. a stale response
+      // for a load superseded by a later navigation) must never overwrite
+      // the current room's presence state.
+      if (`${event.room}` !== `${this.$store.data.place?.id}`) return;
       this.presenceStore.reconcile(event.presences);
     },
     /** A peer joined the room - renderer-independent, may run before X_ITE exists. */
@@ -823,19 +861,48 @@ export default Vue.extend({
       this.$socket.on("AV:del", event => this.onPresenceLeft(event));
       this.$socket.on("AV", event => this.onPresenceMoved(event));
     },
-    /** SE (shared events) only makes sense once an X_ITE scene exists. */
+    /**
+     * SE (shared events) only makes sense once an X_ITE scene exists, so
+     * its listener registration stays gated behind X_ITE readiness rather
+     * than moving to the renderer-independent `startSocketListeners()`.
+     * Any SE sent by a peer in the narrow window after our own JOIN but
+     * before our X_ITE scene finishes loading is dropped: there is no
+     * `eventNodeMap` yet to resolve it against (that's built from the
+     * scene itself in `startSharedEvents()`), so it can't be meaningfully
+     * buffered - loss here is accepted, matching SE's nature as a
+     * momentary signal rather than durable state.
+     *
+     * This method is called once per 3D place load (from
+     * `startX3DListeners`), so the registration itself is guarded to run
+     * only once per component lifetime - `onSharedEvent` always reads the
+     * live `this.eventNodeMap`, which `startSharedEvents()` does rebuild
+     * per place, so one persistent listener is correct and avoids
+     * accumulating a duplicate "SE" handler on every place visited.
+     */
     start3DSocketListeners(): void {
+      if (this.sharedEventListenerRegistered) return;
+      this.sharedEventListenerRegistered = true;
       this.$socket.on("SE", event => this.onSharedEvent(event));
+    },
+    /** True if `presence` is this page's own local user. */
+    isSelf(presence: Presence): boolean {
+      return isSelfPresence(presence, this.$store.data.user.id, this.$socket.presenceId);
     },
     /**
      * Drains whatever presence state already accumulated in presenceStore
      * before X_ITE was ready, then subscribes for live updates. A presence
      * that both joined and left before this ever ran is simply never
      * rendered - it was removed from the store before `all()` was called.
+     * The local user's own presence (present in the store since ROOM_STATE
+     * includes self) is filtered out here - it must never be rendered as a
+     * remote avatar.
      */
     startAvatarRenderer(): void {
-      this.presenceStore.all().forEach(presence => this.renderPresenceAdded(presence));
+      this.presenceStore.all()
+        .filter(presence => !this.isSelf(presence))
+        .forEach(presence => this.renderPresenceAdded(presence));
       this.presenceStore.subscribe(event => {
+        if (this.isSelf(event.presence)) return;
         if (event.type === "add") this.renderPresenceAdded(event.presence);
         if (event.type === "update") this.renderPresenceUpdated(event.presence);
         if (event.type === "remove") this.renderPresenceRemoved(event.key);

--- a/spa/src/pages/world-browser/world-browser-data.interface.ts
+++ b/spa/src/pages/world-browser/world-browser-data.interface.ts
@@ -1,5 +1,9 @@
+import { PresenceStore } from "@/presence";
+
 export interface WorldBrowserData {
     loaded: boolean;
+    chatReady: boolean;
+    presenceStore: PresenceStore;
     worldsData: any;
     avatarsData: any;
     browser: any;

--- a/spa/src/pages/world-browser/world-browser-data.interface.ts
+++ b/spa/src/pages/world-browser/world-browser-data.interface.ts
@@ -4,6 +4,8 @@ export interface WorldBrowserData {
     loaded: boolean;
     chatReady: boolean;
     presenceStore: PresenceStore;
+    loadGeneration: number;
+    sharedEventListenerRegistered: boolean;
     worldsData: any;
     avatarsData: any;
     browser: any;

--- a/spa/src/presence.ts
+++ b/spa/src/presence.ts
@@ -32,6 +32,23 @@ export function presenceKey(memberId: number | string, presenceId: string): stri
   return `${memberId}:${presenceId}`;
 }
 
+/**
+ * True if `presence` is the local user's own (same member, same tab).
+ * Used to keep the local user out of the remote-avatar renderer and out of
+ * Chat's roster, matching CTR's established behavior of never showing
+ * yourself as a "remote" entry - self identity must be compared by logical
+ * key, never by socket id (which changes on every reconnect).
+ */
+export function isSelfPresence(
+  presence: { memberId: number | string; presenceId: string },
+  myMemberId: number | string,
+  myPresenceId: string,
+): boolean {
+  const theirKey = presenceKey(presence.memberId, presence.presenceId);
+  const myKey = presenceKey(myMemberId, myPresenceId);
+  return theirKey === myKey;
+}
+
 export interface ReconcileResult {
   added: Presence[];
   updated: Presence[];

--- a/spa/src/presence.ts
+++ b/spa/src/presence.ts
@@ -1,0 +1,152 @@
+/**
+ * Renderer-independent presence model shared by Chat and the X_ITE avatar layer.
+ *
+ * Identity is intentionally split into three concepts that must never be
+ * collapsed into one another:
+ * - memberId: stable account identity, taken only from the verified JWT.
+ * - presenceId: a random per-tab/page-instance id, generated client-side and
+ *   held only in memory (never localStorage) so two tabs on the same account
+ *   remain distinct presences.
+ * - socketId: the current Socket.IO transport id, which is replaceable
+ *   transport metadata and must never be used as a logical identity key.
+ */
+
+/** [x, y, z] - matches the wire format already used by AV pos payloads. */
+export type Position3 = [number, number, number];
+
+/** [x, y, z, angle] - matches the wire format already used by AV rot payloads. */
+export type Rotation4 = [number, number, number, number];
+
+export interface Presence {
+  memberId: number;
+  presenceId: string;
+  socketId: string;
+  username: string;
+  avatar?: any;
+  pos?: Position3;
+  rot?: Rotation4;
+}
+
+/** Builds the logical presence key that identifies a presence across reconnects. */
+export function presenceKey(memberId: number | string, presenceId: string): string {
+  return `${memberId}:${presenceId}`;
+}
+
+export interface ReconcileResult {
+  added: Presence[];
+  updated: Presence[];
+  removed: Presence[];
+}
+
+type PresenceEvent =
+  | { type: "add"; presence: Presence }
+  | { type: "update"; presence: Presence }
+  | { type: "remove"; key: string; presence: Presence };
+
+type PresenceListener = (event: PresenceEvent) => void;
+
+/**
+ * Authoritative, renderer-independent store of who is currently present.
+ * Consumers (Chat roster, X_ITE avatar renderer) subscribe to changes and/or
+ * pull the current snapshot with `all()` whenever they become ready to render
+ * it — the store itself never depends on whether anyone is listening or
+ * whether a 3D scene exists yet.
+ */
+export class PresenceStore {
+  private byKey = new Map<string, Presence>();
+  private listeners = new Set<PresenceListener>();
+
+  /** Subscribes to add/update/remove events. Returns an unsubscribe function. */
+  public subscribe(listener: PresenceListener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  private emit(event: PresenceEvent): void {
+    this.listeners.forEach(listener => listener(event));
+  }
+
+  public get(key: string): Presence | undefined {
+    return this.byKey.get(key);
+  }
+
+  public has(key: string): boolean {
+    return this.byKey.has(key);
+  }
+
+  /** All current presences. Safe to call at any time, X_ITE-ready or not. */
+  public all(): Presence[] {
+    return Array.from(this.byKey.values());
+  }
+
+  /**
+   * Adds a presence or merges fields into an existing one (e.g. a new
+   * socketId after the transport metadata changes, or an updated transform).
+   * Repeated calls for the same key collapse to the latest values only.
+   */
+  public upsert(next: Presence): Presence {
+    const key = presenceKey(next.memberId, next.presenceId);
+    const existing = this.byKey.get(key);
+    const merged: Presence = existing ? { ...existing, ...next } : { ...next };
+    this.byKey.set(key, merged);
+    this.emit({ type: existing ? "update" : "add", presence: merged });
+    return merged;
+  }
+
+  /** Updates only the transform fields of an existing presence, if present. */
+  public updateTransform(key: string, pos?: Position3, rot?: Rotation4): Presence | undefined {
+    const existing = this.byKey.get(key);
+    if (!existing) return undefined;
+    if (pos) existing.pos = pos;
+    if (rot) existing.rot = rot;
+    this.emit({ type: "update", presence: existing });
+    return existing;
+  }
+
+  public remove(key: string): Presence | undefined {
+    const existing = this.byKey.get(key);
+    if (!existing) return undefined;
+    this.byKey.delete(key);
+    this.emit({ type: "remove", key, presence: existing });
+    return existing;
+  }
+
+  /** Removes everything with no per-entry events (used on place navigation). */
+  public clear(): void {
+    this.byKey.clear();
+  }
+
+  /**
+   * Applies an authoritative snapshot (e.g. a ROOM_STATE payload): adds
+   * genuinely new presences, updates existing ones in place (no duplicate
+   * roster entries, no duplicate avatar loads), and removes anything present
+   * locally but absent from the snapshot (clears ghosts left by a hard
+   * restart or a missed disconnect).
+   */
+  public reconcile(snapshot: Presence[]): ReconcileResult {
+    const incomingKeys = new Set(snapshot.map(p => presenceKey(p.memberId, p.presenceId)));
+    const removed: Presence[] = [];
+
+    for (const key of Array.from(this.byKey.keys())) {
+      if (!incomingKeys.has(key)) {
+        const gone = this.remove(key);
+        if (gone) removed.push(gone);
+      }
+    }
+
+    const added: Presence[] = [];
+    const updated: Presence[] = [];
+    for (const presence of snapshot) {
+      const key = presenceKey(presence.memberId, presence.presenceId);
+      const existedBefore = this.byKey.has(key);
+      const result = this.upsert(presence);
+      if (existedBefore) {
+        updated.push(result);
+      } else {
+        added.push(result);
+      }
+    }
+
+    return { added, updated, removed };
+  }
+}

--- a/spa/src/socket.ts
+++ b/spa/src/socket.ts
@@ -1,6 +1,7 @@
 import * as SocketIO from "socket.io-client";
 
 import { debugMsg } from '@/helpers';
+import { joinRoomOverSocket } from "./join-protocol";
 
 /**
  * Generates a random per-tab presence id. Held only in memory for the
@@ -48,20 +49,16 @@ class SocketManager {
   }
 
   /**
-   * Joins the room with the given room id.
+   * Joins the room with the given room id and waits for the server's
+   * authoritative confirmation (a matching ROOM_STATE) before resolving.
+   * Rejects on JOIN:error or if no response arrives within the timeout -
+   * callers must not treat this as "joined" until it resolves.
    * @param roomId id of room to join
    * @param userToken user's unique token
-   * @returns promise to be resolved on join
+   * @returns promise resolved once the server confirms the join, rejected on error/timeout
    */
   public joinRoom(roomId: string|number, userToken: string): Promise<void> {
-    return new Promise(resolve => {
-      this.socket.emit("JOIN", {
-        room: roomId,
-        token: userToken,
-        presenceId: this.presenceIdValue,
-      });
-      resolve();
-    });
+    return joinRoomOverSocket(this.socket, roomId, userToken, this.presenceIdValue);
   }
 
   /**
@@ -80,6 +77,18 @@ class SocketManager {
    */
   public on(event: string, callback: (...args: any[]) => void): SocketIO.Socket {
     return this.socket.on(event, callback);
+  }
+
+  /**
+   * Removes a previously registered event handler. Needed by any listener
+   * that shouldn't accumulate duplicates across repeated registration
+   * (e.g. component remounts, place navigation).
+   * @param event name of event
+   * @param callback the exact function passed to a prior `on()` call
+   * @returns socket instance
+   */
+  public off(event: string, callback?: (...args: any[]) => void): SocketIO.Socket {
+    return this.socket.off(event, callback);
   }
 
   /**

--- a/spa/src/socket.ts
+++ b/spa/src/socket.ts
@@ -2,10 +2,30 @@ import * as SocketIO from "socket.io-client";
 
 import { debugMsg } from '@/helpers';
 
+/**
+ * Generates a random per-tab presence id. Held only in memory for the
+ * lifetime of this page instance - never persisted to localStorage or
+ * otherwise shared across tabs, so two tabs on the same account always
+ * present as two distinct presences.
+ */
+function generatePresenceId(): string {
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
 class SocketManager {
   private socket: SocketIO.Socket;
+  private readonly presenceIdValue: string = generatePresenceId();
 
   constructor() {}
+
+  /**
+   * The random per-tab presence id for this page instance. Combined with
+   * the JWT-derived member id server-side to form the logical presence key
+   * `memberId:presenceId` - never the transport-level socket id.
+   */
+  public get presenceId(): string {
+    return this.presenceIdValue;
+  }
 
   /**
    * Determines if the socket is currently connected.
@@ -38,6 +58,7 @@ class SocketManager {
       this.socket.emit("JOIN", {
         room: roomId,
         token: userToken,
+        presenceId: this.presenceIdValue,
       });
       resolve();
     });

--- a/spa/tests/presence.test.ts
+++ b/spa/tests/presence.test.ts
@@ -7,12 +7,18 @@
  * change). Compile and run with `npm test` (see package.json / tests/tsconfig.json).
  */
 import assert from "assert";
-import { PresenceStore, presenceKey, Presence } from "../src/presence";
+import { EventEmitter } from "events";
+import { PresenceStore, presenceKey, isSelfPresence, Presence } from "../src/presence";
+import { joinRoomOverSocket } from "../src/join-protocol";
 
-type Test = { name: string; run: () => void };
+type Test = { name: string; run: () => void | Promise<void> };
 const tests: Test[] = [];
-function test(name: string, run: () => void): void {
+function test(name: string, run: () => void | Promise<void>): void {
   tests.push({ name, run });
+}
+/** Purely cosmetic grouping - `test()` collects into one flat list regardless of nesting. */
+function describe(_name: string, run: () => void): void {
+  run();
 }
 
 function makePresence(overrides: Partial<Presence> = {}): Presence {
@@ -173,19 +179,98 @@ test("reconciling twice with the same snapshot produces no duplicates", () => {
   assert.strictEqual(store.all().length, 1);
 });
 
-let failures = 0;
-for (const { name, run } of tests) {
-  try {
-    run();
-    console.log(`  ✓ ${name}`);
-  } catch (err) {
-    failures += 1;
-    console.error(`  ✗ ${name}`);
-    console.error(err instanceof Error ? `    ${err.message}` : err);
+test("isSelfPresence matches the same member and tab", () => {
+  assert.strictEqual(isSelfPresence(makePresence({ memberId: 1, presenceId: "tab-a" }), 1, "tab-a"), true);
+});
+
+test("isSelfPresence does not match a different tab of the same member", () => {
+  assert.strictEqual(isSelfPresence(makePresence({ memberId: 1, presenceId: "tab-a" }), 1, "tab-b"), false);
+});
+
+test("isSelfPresence does not match a different member using the same tab id", () => {
+  assert.strictEqual(isSelfPresence(makePresence({ memberId: 1, presenceId: "tab-a" }), 2, "tab-a"), false);
+});
+
+describe("joinRoomOverSocket", () => {
+  function makeFakeSocket() {
+    const emitter = new EventEmitter();
+    const emitted: any[] = [];
+    const socket = {
+      on: (event: string, cb: (...args: any[]) => void) => emitter.on(event, cb),
+      off: (event: string, cb: (...args: any[]) => void) => emitter.off(event, cb),
+      emit: (event: string, ...args: any[]) => {
+        emitted.push({ event, args });
+        if (event === "JOIN") return; // client->server emit, not looped back automatically
+        emitter.emit(event, ...args);
+      },
+    };
+    return { socket, emitter, emitted };
+  }
+
+  test("resolves once the server confirms with a ROOM_STATE for the requested room", async () => {
+    const { socket, emitter, emitted } = makeFakeSocket();
+    const promise = joinRoomOverSocket(socket, "room-1", "token", "presence-1");
+
+    assert.strictEqual(emitted[0].event, "JOIN");
+    assert.deepStrictEqual(emitted[0].args[0], { room: "room-1", token: "token", presenceId: "presence-1" });
+
+    emitter.emit("ROOM_STATE", { room: "room-1", presences: [] });
+    await promise;
+  });
+
+  test("ignores a ROOM_STATE for a different room and keeps waiting", async () => {
+    const { socket, emitter } = makeFakeSocket();
+    const promise = joinRoomOverSocket(socket, "room-1", "token", "presence-1");
+
+    emitter.emit("ROOM_STATE", { room: "some-other-room", presences: [] });
+    emitter.emit("ROOM_STATE", { room: "room-1", presences: [] });
+
+    await promise; // must not hang/reject - the second, matching event resolves it
+  });
+
+  test("rejects on JOIN:error instead of resolving", async () => {
+    const { socket, emitter } = makeFakeSocket();
+    const promise = joinRoomOverSocket(socket, "room-1", "token", "presence-1");
+
+    emitter.emit("JOIN:error", { reason: "invalid_token" });
+
+    await assert.rejects(promise, /invalid_token/);
+  });
+
+  test("rejects if no response arrives before the timeout", async () => {
+    const { socket } = makeFakeSocket();
+    const promise = joinRoomOverSocket(socket, "room-1", "token", "presence-1", 20);
+
+    await assert.rejects(promise, /timed out/);
+  });
+
+  test("a late ROOM_STATE after timeout/rejection does not resolve the already-settled promise", async () => {
+    const { socket, emitter } = makeFakeSocket();
+    const promise = joinRoomOverSocket(socket, "room-1", "token", "presence-1", 20);
+
+    await assert.rejects(promise);
+    // Should not throw or double-resolve - listeners were cleaned up on timeout.
+    emitter.emit("ROOM_STATE", { room: "room-1", presences: [] });
+  });
+});
+
+async function run(): Promise<void> {
+  let failures = 0;
+  for (const { name, run: runTest } of tests) {
+    try {
+      await runTest();
+      console.log(`  ✓ ${name}`);
+    } catch (err) {
+      failures += 1;
+      console.error(`  ✗ ${name}`);
+      console.error(err instanceof Error ? `    ${err.message}` : err);
+    }
+  }
+
+  console.log(`\n${tests.length - failures}/${tests.length} passed`);
+  if (failures > 0) {
+    process.exit(1);
   }
 }
 
-console.log(`\n${tests.length - failures}/${tests.length} passed`);
-if (failures > 0) {
-  process.exit(1);
-}
+run();

--- a/spa/tests/presence.test.ts
+++ b/spa/tests/presence.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Dependency-free tests for the presence store. No test framework is added
+ * as a devDependency - this project's webpack/babel toolchain is old enough
+ * that installing jest/babel-jest destabilizes it (verified: doing so broke
+ * `npm run build` with an unrelated "Unknown helper regeneratorRuntime"
+ * error caused by npm's flat node_modules hoisting, not by any source
+ * change). Compile and run with `npm test` (see package.json / tests/tsconfig.json).
+ */
+import assert from "assert";
+import { PresenceStore, presenceKey, Presence } from "../src/presence";
+
+type Test = { name: string; run: () => void };
+const tests: Test[] = [];
+function test(name: string, run: () => void): void {
+  tests.push({ name, run });
+}
+
+function makePresence(overrides: Partial<Presence> = {}): Presence {
+  return {
+    memberId: 1,
+    presenceId: "tab-a",
+    socketId: "socket-1",
+    username: "alice",
+    avatar: { id: "a1" },
+    pos: [0, 0, 0],
+    rot: [0, 1, 0, 0],
+    ...overrides,
+  };
+}
+
+test("presenceKey combines memberId and presenceId into a stable composite key", () => {
+  assert.strictEqual(presenceKey(1, "tab-a"), "1:tab-a");
+});
+
+test("presenceKey keeps two tabs on the same member distinct", () => {
+  assert.notStrictEqual(presenceKey(1, "tab-a"), presenceKey(1, "tab-b"));
+});
+
+test("upsert adds a new presence and emits an add event", () => {
+  const store = new PresenceStore();
+  const events: string[] = [];
+  store.subscribe(e => events.push(e.type));
+
+  const result = store.upsert(makePresence());
+
+  assert.strictEqual(result.username, "alice");
+  assert.strictEqual(store.all().length, 1);
+  assert.deepStrictEqual(events, ["add"]);
+});
+
+test("upsert on an existing key merges fields and emits update, not add", () => {
+  const store = new PresenceStore();
+  store.upsert(makePresence({ socketId: "socket-1" }));
+
+  const events: string[] = [];
+  store.subscribe(e => events.push(e.type));
+  store.upsert(makePresence({ socketId: "socket-2" }));
+
+  assert.strictEqual(store.all().length, 1);
+  assert.strictEqual(store.get(presenceKey(1, "tab-a"))?.socketId, "socket-2");
+  assert.deepStrictEqual(events, ["update"]);
+});
+
+test("repeated movement updates collapse to only the latest transform", () => {
+  const store = new PresenceStore();
+  const key = presenceKey(1, "tab-a");
+  store.upsert(makePresence());
+
+  store.updateTransform(key, [1, 0, 0]);
+  store.updateTransform(key, [2, 0, 0]);
+  store.updateTransform(key, [3, 0, 0]);
+
+  assert.strictEqual(store.all().length, 1);
+  assert.deepStrictEqual(store.get(key)?.pos, [3, 0, 0]);
+});
+
+test("a presence removed before ever being drained never appears in all()", () => {
+  const store = new PresenceStore();
+  const key = presenceKey(1, "tab-a");
+  store.upsert(makePresence());
+  store.remove(key);
+
+  // Simulates a consumer (e.g. X_ITE) becoming ready only after the
+  // presence already left - it must never see it.
+  assert.strictEqual(store.all().length, 0);
+});
+
+test("remove emits a remove event carrying the removed presence", () => {
+  const store = new PresenceStore();
+  const key = presenceKey(1, "tab-a");
+  store.upsert(makePresence());
+
+  const events: any[] = [];
+  store.subscribe(e => events.push(e));
+  const removed = store.remove(key);
+
+  assert.strictEqual(removed?.username, "alice");
+  assert.strictEqual(events.length, 1);
+  assert.deepStrictEqual(events[0], { type: "remove", key, presence: removed });
+});
+
+test("clear removes everything without per-entry events", () => {
+  const store = new PresenceStore();
+  store.upsert(makePresence());
+  store.upsert(makePresence({ presenceId: "tab-b", memberId: 2 }));
+
+  const events: string[] = [];
+  store.subscribe(e => events.push(e.type));
+  store.clear();
+
+  assert.strictEqual(store.all().length, 0);
+  assert.strictEqual(events.length, 0);
+});
+
+test("reconcile adds presences that are new in the snapshot", () => {
+  const store = new PresenceStore();
+  const result = store.reconcile([makePresence()]);
+
+  assert.strictEqual(result.added.length, 1);
+  assert.strictEqual(result.updated.length, 0);
+  assert.strictEqual(result.removed.length, 0);
+  assert.strictEqual(store.all().length, 1);
+});
+
+test("reconcile updates presences already known, without duplicating them", () => {
+  const store = new PresenceStore();
+  store.upsert(makePresence({ socketId: "socket-1" }));
+
+  const result = store.reconcile([makePresence({ socketId: "socket-2" })]);
+
+  assert.strictEqual(result.added.length, 0);
+  assert.strictEqual(result.updated.length, 1);
+  assert.strictEqual(store.all().length, 1);
+  assert.strictEqual(store.get(presenceKey(1, "tab-a"))?.socketId, "socket-2");
+});
+
+test("reconcile removes presences absent from an authoritative snapshot", () => {
+  const store = new PresenceStore();
+  store.upsert(makePresence({ presenceId: "tab-a" }));
+  store.upsert(makePresence({ memberId: 2, presenceId: "tab-b", username: "bob" }));
+
+  // Authoritative snapshot only contains alice - bob is a ghost (e.g. left
+  // during a hard restart without a clean disconnect) and must go.
+  const result = store.reconcile([makePresence({ presenceId: "tab-a" })]);
+
+  assert.strictEqual(result.removed.length, 1);
+  assert.strictEqual(result.removed[0].username, "bob");
+  assert.strictEqual(store.all().length, 1);
+  assert.strictEqual(store.all()[0].username, "alice");
+});
+
+test("reconcile keeps two tabs of the same member as separate presences", () => {
+  const store = new PresenceStore();
+  const snapshot = [
+    makePresence({ presenceId: "tab-a", socketId: "socket-1" }),
+    makePresence({ presenceId: "tab-b", socketId: "socket-2" }),
+  ];
+
+  store.reconcile(snapshot);
+
+  assert.strictEqual(store.all().length, 2);
+  assert.strictEqual(store.has(presenceKey(1, "tab-a")), true);
+  assert.strictEqual(store.has(presenceKey(1, "tab-b")), true);
+});
+
+test("reconciling twice with the same snapshot produces no duplicates", () => {
+  const store = new PresenceStore();
+  const snapshot = [makePresence()];
+
+  store.reconcile(snapshot);
+  store.reconcile(snapshot);
+
+  assert.strictEqual(store.all().length, 1);
+});
+
+let failures = 0;
+for (const { name, run } of tests) {
+  try {
+    run();
+    console.log(`  ✓ ${name}`);
+  } catch (err) {
+    failures += 1;
+    console.error(`  ✗ ${name}`);
+    console.error(err instanceof Error ? `    ${err.message}` : err);
+  }
+}
+
+console.log(`\n${tests.length - failures}/${tests.length} passed`);
+if (failures > 0) {
+  process.exit(1);
+}

--- a/spa/tests/tsconfig.json
+++ b/spa/tests/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "es2019",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "./.compiled",
+    "types": ["node"]
+  },
+  "include": ["*.ts", "../src/presence.ts"]
+}

--- a/spa/tsconfig.json
+++ b/spa/tsconfig.json
@@ -16,7 +16,8 @@
     "sourceMap": true,
     "baseUrl": ".",
     "types": [
-      "webpack-env"
+      "webpack-env",
+      "node"
     ],
     "paths": {
       "@/*": [


### PR DESCRIPTION
## Summary

Establishes the socket presence foundation needed for reliable reconnect recovery by separating authenticated room and Chat presence from X_ITE scene initialization.

This is the first application phase of the work related to #69. Automatic reconnect and resynchronization are deliberately deferred to a follow-up PR.

## Root cause

CTR previously joined the active socket room only after a 3D X_ITE scene finished initializing. Chat readiness, room membership, avatar presence, and rendering readiness were therefore coupled together.

Socket.IO transport reconnection also creates a new socket ID, while the existing implementation treated that temporary socket ID as presence identity.

## What changed

- Added stable logical presence identity using:
  - JWT-derived member ID
  - In-memory, tab-scoped presence ID
- Treats socket ID only as replaceable transport metadata.
- Added an authoritative `ROOM_STATE` snapshot for initial membership.
- Added confirmed JOIN success, explicit JOIN errors, and timeout handling.
- Added a renderer-independent presence store shared by Chat and the X_ITE avatar renderer.
- Decoupled authenticated room and Chat readiness from X_ITE initialization.
- Added latest-state buffering before X_ITE becomes ready.
- Added authoritative reconciliation for additions, updates, and removals.
- Prevented the local user from rendering or appearing as a duplicate remote presence.
- Preserved distinct simultaneous tabs for the same member.
- Hardened repeated JOINs and room transitions.
- Fixed socket-listener accumulation during place navigation.
- Fixed asynchronous avatar-load removal races.
- Fixed initial Chat roster initialization so stationary pre-existing occupants appear immediately from `ROOM_STATE`.
- Preserved existing 2D, 3D, Chat, shared-object, and shared-event behavior.

## Validation

- `npm test`: 21/21 passing.
- `npm run build`: passing.
- No new runtime or development dependencies.
- No package-lock change.
- Real Socket.IO protocol QA passed.
- Real Chromium/X_ITE browser QA passed for:
  - Chat readiness before X_ITE initialization
  - Self-presence filtering
  - Stationary pre-existing occupants appearing immediately from `ROOM_STATE`
  - Two different members in one room
  - Two tabs using the same member account
  - Same-account 3D-status behavior as presences leave individually
  - Repeated 2D/3D and cross-place navigation
  - Overlapping place loads
  - Delayed avatar-loading cancellation
  - Invalid JOIN handling
  - User homes and shops
  - Chat, movement, shared objects, and shared events
- Listener counts remained stable across repeated navigation.
- Independent Copilot CLI reviews were individually adjudicated.
- Every reproduced branch defect was fixed and re-verified.

## Deliberately deferred

This PR does not implement:

- Automatic transport reconnect and room rejoin
- Reconnect-triggered authoritative resynchronization
- Room tags on every presence event
- JOIN request correlation IDs
- Duplicate-login enforcement from #92
- Session expiration or refresh
- Cross-tab logout
- Moving the socket service into the API
- Production watcher or proxy changes

Those protocol additions belong in the follow-up reconnect and resynchronization PR.

## Known residual risk

Presence events do not yet carry room IDs, and JOIN snapshots do not yet carry request correlation IDs.

A narrowly timed stale event can transiently enter the local store during navigation, but the next authoritative room snapshot removes it. The complete protocol-level correction belongs with reconnect and resynchronization in the follow-up PR.

## Issue relationship

Related to #69.

This PR establishes the required foundation. Follow-up reconnect and resynchronization work remains.
