### PR TITLE
Add admin button to main menu

### DIFF
--- a/spa/src/App.vue
+++ b/spa/src/App.vue
@@ -103,13 +103,15 @@
               <br />
               <router-view name="tools"></router-view>
               <button
-                v-if="accessLevel && accessLevel.length > 0"
+                v-if="accessLevel && accessLevel !== 'none' && accessLevel.length > 0"
                 class="btn-ui"
                 @click="openWindow('#/admin/')"
               >
                 <span style="color: red;">Admin</span>
               </button>
-              <br v-if="accessLevel && accessLevel.length > 0" />
+              <br
+                v-if="accessLevel && accessLevel !== 'none' && accessLevel.length > 0"
+              />
               <a
                 href="https://github.com/CybertownRevival/ctr/issues"
                 class="btn-ui"
@@ -441,6 +443,15 @@ export default Vue.extend({
     require("./libs/x_ite_mods/extend_context_menu.js");
     require("./libs/x_ite_mods/bxx_auth.js");
     //require('./libs/x_ite_mods/fix_stairs.js');
+  },
+  watch: {
+    '$store.data.isUser'(isUser: boolean): void {
+      if (isUser) {
+        this.checkAccessLevel();
+      } else {
+        this.accessLevel = null;
+      }
+    },
   },
   computed: {
 

--- a/spa/src/App.vue
+++ b/spa/src/App.vue
@@ -102,11 +102,19 @@
             <div>
               <br />
               <router-view name="tools"></router-view>
+              <button
+                v-if="accessLevel && accessLevel.length > 0"
+                class="btn-ui"
+                @click="openWindow('#/admin/')"
+              >
+                <span style="color: red;">Admin</span>
+              </button>
+              <br v-if="accessLevel && accessLevel.length > 0" />
               <a
                 href="https://github.com/CybertownRevival/ctr/issues"
                 class="btn-ui"
                 target="_blank"
-                >
+              >
                 Report a Bug
               </a>
               <br />


### PR DESCRIPTION
Summary

Adds an Admin button to the main CTR navigation menu for users who have access to the existing Admin Panel.
(as i was getting sick of having to edit the address bar lol)

Changes
Adds an Admin button to the main navigation panel.
Only displays the button when the logged-in user has an existing Admin Panel access level.
Uses the existing /member/getadminlevel access control rather than introducing new permission logic.
Displays the Admin text in red to distinguish it from the standard navigation buttons.
Opens the existing Admin Panel in a separate window, allowing the main CTR session to remain open.
Testing
Confirmed the Admin button displays for an authorised user.
Confirmed the Admin Panel opens successfully in a separate window.
Confirmed the main CTR window remains open.
git diff --check completed without errors.