### PR TITLE
Fix fresh database voting setup

### DIFF
--- a/api/db/migrations/20260309032638_add_voting_tables.ts
+++ b/api/db/migrations/20260309032638_add_voting_tables.ts
@@ -56,28 +56,14 @@ export async function up(knex: Knex): Promise<void> {
       // Ensure a member can only vote once per specific poll
       table.unique(['vote_id', 'member_id']);
     });
-  console.log('Adding voting seeds...');
-  await knex('vote_list').insert({
-    title: 'Mayor Election 2026',
-    place_id: 1,
-    creator_member_id: null,
-    description: 'Vote for the next mayor of Cybertown',
-    expires_at: null,
-  });
-  await knex('vote_options').insert([
-    {
-      vote_id: 1,
-      option_text: 'EmperorAjay',
-    },
-    {
-      vote_id: 1,
-      option_text: 'MorningStar',
-    },
-    {
-      vote_id: 1,
-      option_text: 'phil_00',
-    },
-  ]);
+  // The Mayor Election rows this migration used to insert now live in
+  // db/seed/12-votes.seed.ts. They are content, not schema, and inserting them from here
+  // made a fresh database impossible to build: `place_id` is a foreign key into `place`,
+  // and migrations run before seeds, so on an empty database there was no place to point
+  // at. It also assumed the new table would hand out vote id 1 for the options.
+  //
+  // Databases created before this change already ran the migration and already hold these
+  // rows; the seed is idempotent, so it is a no-op for them.
   return;
 }
 

--- a/api/db/scripts/verify-fresh-install.sh
+++ b/api/db/scripts/verify-fresh-install.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+#
+# Regression check: a completely empty database must be buildable with the stock
+# `npm run db:init` lifecycle (create-db -> migrate -> seed).
+#
+# This broke once already: 20260309032638_add_voting_tables inserted the Mayor Election
+# rows itself, and `place_id` is a foreign key into `place`, which seeds only fill in
+# afterwards. Every existing database had the migration recorded so knex never re-ran it,
+# and the breakage stayed invisible until someone set up from scratch.
+#
+#   CTR_FRESH_DB_TEST=1 api/db/scripts/verify-fresh-install.sh
+#
+# Requires docker. It brings up its own throwaway mysql:5.7 and node:14 containers and
+# removes them again; it never reads DB_HOST/DB_DATABASE, so it cannot be pointed at a
+# database you care about.
+
+set -euo pipefail
+
+if [ "${CTR_FRESH_DB_TEST:-}" != "1" ]; then
+  echo "Refusing to run: this test creates and destroys databases." >&2
+  echo "Set CTR_FRESH_DB_TEST=1 to confirm that is what you want." >&2
+  exit 2
+fi
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+SUFFIX="$$-$(date +%s)"
+CONTAINER="ctr-fresh-db-${SUFFIX}"
+NETWORK="ctr-fresh-db-net-${SUFFIX}"
+DB_NAME="ctr_fresh_db_test"
+MYSQL_PASS="pw"
+
+cleanup() {
+  docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+  docker network rm "$NETWORK" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+mysql_exec() {
+  docker exec -i "$CONTAINER" mysql -uroot -p"$MYSQL_PASS" --batch --skip-column-names "$@" 2>/dev/null
+}
+
+# Runs a command in a throwaway node:14 container wired to the disposable database.
+# The env vars are set on the process, and dotenv never overwrites an existing value, so a
+# developer's own api/.env cannot redirect this at another server.
+in_node() {
+  docker run --rm --network "$NETWORK" \
+    -u "$(id -u):$(id -g)" -e HOME=/tmp \
+    -e NODE_ENV=development \
+    -e DB_HOST="$CONTAINER" -e DB_PORT=3306 \
+    -e DB_USER=root -e DB_PASS="$MYSQL_PASS" -e DB_DATABASE="$DB_NAME" \
+    -e JWT_SECRET=fresh-db-test \
+    -v "$REPO_ROOT":/usr/src/app -w /usr/src/app/api \
+    node:14 bash -c "$1"
+}
+
+echo "==> starting disposable mysql:5.7 ($CONTAINER)"
+docker network create "$NETWORK" >/dev/null
+docker run -d --name "$CONTAINER" --network "$NETWORK" \
+  -e MYSQL_ROOT_PASSWORD="$MYSQL_PASS" mysql:5.7 >/dev/null
+
+for _ in $(seq 1 90); do
+  if mysql_exec -e "SELECT 1" >/dev/null 2>&1; then break; fi
+  sleep 2
+done
+mysql_exec -e "SELECT VERSION()" >/dev/null 2>&1 || fail "mysql never became reachable"
+echo "    mysql $(mysql_exec -e 'SELECT VERSION()') is up, database $DB_NAME does not exist yet"
+
+if [ ! -d "$REPO_ROOT/api/node_modules" ]; then
+  echo "==> installing api dependencies"
+  in_node "npm install --no-audit --no-fund" >/dev/null
+fi
+
+echo "==> npm run db:init against the empty database"
+INIT_LOG="$(mktemp)"
+if ! in_node "npm run db:init" >"$INIT_LOG" 2>&1; then
+  sed -n '1,80p' "$INIT_LOG" >&2
+  fail "db:init did not complete on an empty database"
+fi
+
+# Every migration on disk must be recorded, and every seed file must have run.
+MIGRATIONS_ON_DISK="$(find "$REPO_ROOT/api/db/migrations" -maxdepth 1 -name '*.ts' | wc -l)"
+SEEDS_ON_DISK="$(find "$REPO_ROOT/api/db/seed" -maxdepth 1 -name '*.seed.ts' | wc -l)"
+MIGRATIONS_RECORDED="$(mysql_exec "$DB_NAME" -e "SELECT COUNT(*) FROM migrations")"
+SEEDS_RAN="$(grep -oE 'Ran [0-9]+ seed files' "$INIT_LOG" | grep -oE '[0-9]+' | tail -1)"
+
+echo "    migrations: $MIGRATIONS_RECORDED recorded / $MIGRATIONS_ON_DISK on disk"
+echo "    seeds:      ${SEEDS_RAN:-0} ran / $SEEDS_ON_DISK on disk"
+[ "$MIGRATIONS_RECORDED" = "$MIGRATIONS_ON_DISK" ] || fail "not every migration was applied"
+[ "${SEEDS_RAN:-0}" = "$SEEDS_ON_DISK" ] || fail "not every seed ran"
+
+# The poll has to exist, and it has to hang off the canonical place rather than whichever
+# row happened to get id 1.
+POLL="$(mysql_exec "$DB_NAME" -e "
+  SELECT COUNT(*) FROM vote_list v
+  JOIN place p ON p.id = v.place_id
+  WHERE v.title = 'Mayor Election 2026' AND p.slug = 'enter'")"
+OPTIONS="$(mysql_exec "$DB_NAME" -e "
+  SELECT COUNT(*) FROM vote_options o
+  JOIN vote_list v ON v.id = o.vote_id
+  WHERE v.title = 'Mayor Election 2026'")"
+ORPHANS="$(mysql_exec "$DB_NAME" -e "
+  SELECT COUNT(*) FROM vote_options o
+  LEFT JOIN vote_list v ON v.id = o.vote_id WHERE v.id IS NULL")"
+
+echo "    Mayor Election polls at slug 'enter': $POLL, options: $OPTIONS, orphaned options: $ORPHANS"
+[ "$POLL" = "1" ] || fail "expected exactly one Mayor Election poll attached to place 'enter'"
+[ "$OPTIONS" = "3" ] || fail "expected 3 options on the Mayor Election poll, got $OPTIONS"
+[ "$ORPHANS" = "0" ] || fail "vote_options rows point at a poll that does not exist"
+
+# ---------------------------------------------------------------------------------------
+# Second half: the states 12-votes.seed.ts can find when it is not run on a fresh database.
+#
+# Skipping on the title alone was not enough. The poll row and its options are two separate
+# inserts, so a crash between them used to leave an election with no options that every
+# later seed run happily skipped. These cases pin down the transaction and the validation.
+# ---------------------------------------------------------------------------------------
+SEED_LOG="$(mktemp)"
+
+run_votes_seed() {
+  in_node "npx knex seed:run --knexfile src/knexfile.ts --specific=12-votes.seed.ts" \
+    >"$SEED_LOG" 2>&1
+}
+
+polls()   { mysql_exec "$DB_NAME" -e "SELECT COUNT(*) FROM vote_list WHERE title = 'Mayor Election 2026'"; }
+options() { mysql_exec "$DB_NAME" -e "SELECT COUNT(*) FROM vote_options"; }
+
+# Back to the canonical one-poll/three-option state, whatever the previous case did to it.
+reset_votes() {
+  mysql_exec "$DB_NAME" -e "DELETE FROM vote_response; DELETE FROM vote_options; DELETE FROM vote_list;"
+  run_votes_seed || { sed -n '1,40p' "$SEED_LOG" >&2; fail "could not rebuild the canonical vote state"; }
+}
+
+# The seed must refuse loudly, and for the stated reason -- an exit code alone would also be
+# satisfied by an unrelated crash.
+expect_seed_fails() {
+  local case_name="$1" expected="$2"
+  if run_votes_seed; then
+    fail "$case_name: the seed reported success on a state it cannot have produced"
+  fi
+  grep -q "$expected" "$SEED_LOG" || {
+    sed -n '1,40p' "$SEED_LOG" >&2
+    fail "$case_name: the seed failed, but not with the expected '$expected'"
+  }
+  echo "    $case_name -- refused, as expected"
+}
+
+echo "==> re-running the votes seed on a valid state (must be a clean no-op)"
+run_votes_seed || { sed -n '1,40p' "$SEED_LOG" >&2; fail "re-running 12-votes.seed.ts failed"; }
+grep -q 'already present and complete, skipping' "$SEED_LOG" \
+  || fail "the seed re-ran without recognising the existing poll as complete"
+echo "    after rerun -- polls: $(polls), options: $(options)"
+[ "$(polls)" = "1" ] || fail "re-running the seed duplicated the poll"
+[ "$(options)" = "3" ] || fail "re-running the seed duplicated the options"
+
+echo "==> a crash between the poll insert and the options must roll the poll back"
+mysql_exec "$DB_NAME" -e "DELETE FROM vote_response; DELETE FROM vote_options; DELETE FROM vote_list;"
+# A trigger is the least invasive way to make the second insert fail for real, without
+# reimplementing any of the seed: the seed under test is the shipped file, unmodified.
+mysql_exec "$DB_NAME" -e "
+  CREATE TRIGGER ctr_block_vote_options BEFORE INSERT ON vote_options
+  FOR EACH ROW SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'forced failure: rollback test';"
+if run_votes_seed; then fail "the seed survived a forced vote_options failure"; fi
+LEFTOVER="$(polls)"
+echo "    seed failed as forced; Mayor Election rows left behind: $LEFTOVER"
+[ "$LEFTOVER" = "0" ] || fail "the poll row survived a failed options insert -- not atomic"
+mysql_exec "$DB_NAME" -e "DROP TRIGGER ctr_block_vote_options;"
+run_votes_seed || { sed -n '1,40p' "$SEED_LOG" >&2; fail "the seed could not recover once the failure was removed"; }
+echo "    after recovery -- polls: $(polls), options: $(options)"
+[ "$(polls)" = "1" ] || fail "recovery did not produce exactly one poll"
+[ "$(options)" = "3" ] || fail "recovery did not produce exactly three options"
+
+echo "==> a poll that exists but is malformed must be reported, never skipped"
+mysql_exec "$DB_NAME" -e "DELETE FROM vote_options;"
+expect_seed_fails "poll with zero options" "options are wrong"
+
+reset_votes
+mysql_exec "$DB_NAME" -e "DELETE FROM vote_options ORDER BY id LIMIT 1;"
+expect_seed_fails "poll with partial options" "options are wrong"
+
+reset_votes
+mysql_exec "$DB_NAME" -e "
+  UPDATE vote_list SET place_id = (SELECT id FROM place WHERE slug = 'gameshow' ORDER BY id LIMIT 1)
+  WHERE title = 'Mayor Election 2026';"
+expect_seed_fails "poll at the wrong place" "Refusing to move an existing poll"
+
+# vote_list.title carries no unique index, so nothing at the schema level stops a second
+# election from appearing -- a hand-repaired database or two seed runs racing each other
+# can both leave one behind. The seed has to refuse rather than guess which one is real.
+reset_votes
+mysql_exec "$DB_NAME" -e "
+  INSERT INTO vote_list (title, place_id, creator_member_id, description, expires_at)
+  SELECT title, place_id, creator_member_id, description, expires_at
+  FROM vote_list WHERE title = 'Mayor Election 2026' ORDER BY id LIMIT 1;"
+[ "$(polls)" = "2" ] || fail "could not stage the duplicate-poll case"
+BEFORE_DUP="$(mysql_exec "$DB_NAME" -e "
+  SELECT GROUP_CONCAT(CONCAT_WS(':', id, place_id) ORDER BY id) FROM vote_list
+  WHERE title = 'Mayor Election 2026';")"
+expect_seed_fails "two polls with the same title" "expected at most one"
+# Refusing is only half of it -- the seed must not have edited either poll on its way out.
+[ "$(polls)" = "2" ] || fail "the duplicate-poll case changed how many polls exist"
+AFTER_DUP="$(mysql_exec "$DB_NAME" -e "
+  SELECT GROUP_CONCAT(CONCAT_WS(':', id, place_id) ORDER BY id) FROM vote_list
+  WHERE title = 'Mayor Election 2026';")"
+[ "$BEFORE_DUP" = "$AFTER_DUP" ] || fail "the seed modified a poll it had refused to touch"
+[ "$(options)" = "3" ] || fail "the duplicate-poll case changed the option rows"
+
+reset_votes
+echo "    restored -- polls: $(polls), options: $(options)"
+[ "$(polls)" = "1" ] || fail "could not restore the canonical poll"
+[ "$(options)" = "3" ] || fail "could not restore the canonical options"
+
+echo "PASS: an empty database builds with the stock db:init lifecycle, the poll and its"
+echo "      options are written atomically, and a malformed existing poll is never skipped."

--- a/api/db/scripts/verify-fresh-install.sh
+++ b/api/db/scripts/verify-fresh-install.sh
@@ -80,8 +80,11 @@ if ! in_node "npm run db:init" >"$INIT_LOG" 2>&1; then
 fi
 
 # Every migration on disk must be recorded, and every seed file must have run.
-MIGRATIONS_ON_DISK="$(find "$REPO_ROOT/api/db/migrations" -maxdepth 1 -name '*.ts' | wc -l)"
-SEEDS_ON_DISK="$(find "$REPO_ROOT/api/db/seed" -maxdepth 1 -name '*.seed.ts' | wc -l)"
+# The counts are compared as strings against MySQL output, and `wc -l` pads its result with
+# leading blanks on some platforms, so strip everything that is not a digit first.
+count_files() { find "$1" -maxdepth 1 -name "$2" | wc -l | tr -cd '0-9'; }
+MIGRATIONS_ON_DISK="$(count_files "$REPO_ROOT/api/db/migrations" '*.ts')"
+SEEDS_ON_DISK="$(count_files "$REPO_ROOT/api/db/seed" '*.seed.ts')"
 MIGRATIONS_RECORDED="$(mysql_exec "$DB_NAME" -e "SELECT COUNT(*) FROM migrations")"
 SEEDS_RAN="$(grep -oE 'Ran [0-9]+ seed files' "$INIT_LOG" | grep -oE '[0-9]+' | tail -1)"
 
@@ -124,7 +127,12 @@ run_votes_seed() {
 }
 
 polls()   { mysql_exec "$DB_NAME" -e "SELECT COUNT(*) FROM vote_list WHERE title = 'Mayor Election 2026'"; }
-options() { mysql_exec "$DB_NAME" -e "SELECT COUNT(*) FROM vote_options"; }
+# Scoped to the Mayor Election by title rather than counting the whole table: an unrelated
+# poll seeded later must not make these assertions fail. The id is looked up, never assumed.
+options() { mysql_exec "$DB_NAME" -e "
+  SELECT COUNT(*) FROM vote_options o
+  JOIN vote_list v ON v.id = o.vote_id
+  WHERE v.title = 'Mayor Election 2026'"; }
 
 # Back to the canonical one-poll/three-option state, whatever the previous case did to it.
 reset_votes() {

--- a/api/db/seed/12-votes.seed.ts
+++ b/api/db/seed/12-votes.seed.ts
@@ -1,0 +1,119 @@
+import { Knex } from 'knex';
+
+const VOTE_TITLE = 'Mayor Election 2026';
+const PLACE_SLUG = 'enter';
+// The candidates 20260309032638_add_voting_tables used to insert, in its own order.
+const CANDIDATES = ['EmperorAjay', 'MorningStar', 'phil_00'];
+
+/**
+ * The Mayor Election poll, moved out of 20260309032638_add_voting_tables.
+ *
+ * It used to be inserted by that migration, which meant a fresh database could not be
+ * built at all: `place_id` is a foreign key into `place`, migrations run before seeds, and
+ * on an empty database there is no place to point at. `npm run db:init` died on the
+ * constraint before it ever reached the seeds.
+ *
+ * Resolving the place by slug rather than hardcoding id 1 also drops the assumption that
+ * The Plaza is always row 1 -- true for a freshly seeded database, not guaranteed for one
+ * rebuilt or restored in another order.
+ *
+ * The poll and its options are written in one transaction, so a crash between the two
+ * inserts cannot leave a permanently optionless election behind: either the whole poll
+ * lands or none of it does.
+ *
+ * Re-running is a no-op, but only once the poll is confirmed complete and in the right
+ * place. A poll that is present but malformed is reported, not skipped and not rewritten --
+ * repairing existing voting data is somebody's deliberate decision, not a seed's.
+ */
+export async function seed(knex: Knex): Promise<void> {
+  await knex.transaction(async (trx) => {
+    // `place.slug` lost its unique index in 20221019132059_place.map.images, so order the
+    // lookup rather than trusting the storage engine to hand back the original row.
+    const plaza = await trx('place')
+      .where({ slug: PLACE_SLUG })
+      .orderBy('id')
+      .first('id');
+    if (!plaza) {
+      // Seeds run in filename order, so 02-places has already run in a normal db:init.
+      // Failing loudly beats attaching the poll to some other place.
+      throw new Error(
+        `12-votes.seed: no place with slug '${PLACE_SLUG}' -- run the place seeds first`,
+      );
+    }
+
+    const existing = await trx('vote_list')
+      .where({ title: VOTE_TITLE })
+      .orderBy('id')
+      .select('id', 'place_id');
+
+    if (existing.length > 1) {
+      throw new Error(
+        `12-votes.seed: found ${existing.length} polls titled '${VOTE_TITLE}'; ` +
+        'expected at most one. Resolve the duplicates before seeding.',
+      );
+    }
+
+    if (existing.length === 1) {
+      await assertExistingPollIsUsable(trx, existing[0], plaza.id);
+      console.log(`'${VOTE_TITLE}' already present and complete, skipping`);
+      return;
+    }
+
+    console.log('Seeding Mayor Election vote data');
+
+    // The id is read back rather than assumed to be 1: the options are only correct if they
+    // point at the poll actually created here. MySQL has no RETURNING, so this is the
+    // insert-then-read form knex gives us.
+    const [voteId] = await trx('vote_list').insert({
+      title: VOTE_TITLE,
+      place_id: plaza.id,
+      creator_member_id: null,
+      description: 'Vote for the next mayor of Cybertown',
+      expires_at: null,
+    });
+
+    await trx('vote_options').insert(
+      CANDIDATES.map(option_text => ({ vote_id: voteId, option_text })),
+    );
+  });
+}
+
+/**
+ * A poll with the right title is not automatically the poll we meant to seed. Skipping on
+ * the title alone is what let a half-written election survive every later seed run.
+ */
+async function assertExistingPollIsUsable(
+  trx: Knex.Transaction,
+  poll: { id: number; place_id: number },
+  expectedPlaceId: number,
+): Promise<void> {
+  if (poll.place_id !== expectedPlaceId) {
+    throw new Error(
+      `12-votes.seed: '${VOTE_TITLE}' (vote_list id ${poll.id}) is attached to place ` +
+      `${poll.place_id}, but the seeded election belongs to the place with slug ` +
+      `'${PLACE_SLUG}' (id ${expectedPlaceId}). Refusing to move an existing poll -- ` +
+      'correct vote_list.place_id by hand if this is a bootstrap artefact.',
+    );
+  }
+
+  const found: string[] = await trx('vote_options')
+    .where({ vote_id: poll.id })
+    .pluck('option_text');
+  const missing = CANDIDATES.filter(candidate => !found.includes(candidate));
+
+  // Length is checked as well as membership, so a duplicated candidate row is caught too.
+  // That is why the surplus is reported as "unexpected option rows" rather than as
+  // unrecognised values: a second copy of a candidate we do expect still counts here.
+  if (missing.length > 0 || found.length !== CANDIDATES.length) {
+    const unexpected = found.length - (CANDIDATES.length - missing.length);
+    throw new Error(
+      `12-votes.seed: '${VOTE_TITLE}' (vote_list id ${poll.id}) already exists but its ` +
+      `options are wrong: expected ${CANDIDATES.length}, found ${found.length}` +
+      `${missing.length > 0 ? `, missing ${missing.join(', ')}` : ''}` +
+      `${unexpected > 0 ? `, ${unexpected} unexpected ` +
+        `option row${unexpected === 1 ? '' : 's'}` : ''}. ` +
+      'Repair the vote_options rows by hand -- this seed will not rewrite existing ' +
+      'voting data.',
+    );
+  }
+}


### PR DESCRIPTION
## Summary

A fresh database cannot currently complete `npm run db:init`.

The voting migration creates the vote tables and immediately inserts a
demo poll that references `place_id = 1`.

At migration time, the place seeds have not run yet.

MySQL 5.7 therefore fails with `ER_NO_REFERENCED_ROW_2`.

The failed DDL also leaves the vote tables behind.

A migration retry then fails with `ER_TABLE_EXISTS_ERROR`.

## Fix

- Keep the voting migration schema-only.
- Move the Mayor Election demo data into normal seed ordering.
- Resolve The Plaza by slug instead of assuming a place ID.
- Create the poll and options in one transaction.
- Validate an existing poll before treating the seed as complete.
- Add a disposable MySQL 5.7 fresh-install regression harness.

## Validation

Tested with Node 14.21.3 and MySQL 5.7.44.

Fresh install:

- all migrations complete
- all seeds complete
- one Mayor Election is created
- three candidate options are created
- zero orphan options remain

The regression harness also verifies:

- clean seed rerun
- rollback on option insert failure
- zero-option refusal
- partial-option refusal
- wrong-place refusal
- duplicate-title refusal

TypeScript, ESLint, and Bash syntax checks pass.

The normal Jest result is unchanged from current `master`.

## Scope

This PR changes only:

- `api/db/migrations/20260309032638_add_voting_tables.ts`
- `api/db/seed/12-votes.seed.ts`
- `api/db/scripts/verify-fresh-install.sh`
